### PR TITLE
Upload Request Builder and Tests

### DIFF
--- a/Examples/SwiftUIDemo/SwiftUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftUIDemo/SwiftUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable",
+      "state" : {
+        "revision" : "56901f2af3625b38924d488b612e95fe8846ee9b",
+        "version" : "0.6.6"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "lytics",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v14)
     ],
     products: [
         .library(

--- a/Sources/Lytics/Byte.swift
+++ b/Sources/Lytics/Byte.swift
@@ -1,0 +1,38 @@
+//
+//  Byte.swift
+//
+//  Created by Mathew Gacy on 10/20/22.
+//
+
+import Foundation
+
+/// An 8-bit unsigned integer.
+public typealias Byte = UInt8
+
+/// An array of 8-bit unsigned integers.
+public typealias Bytes = [Byte]
+
+/// Adds control character conveniences to `Byte`.
+extension Byte {
+    /// '\n'
+    public static let newLine: Byte = 0xA
+
+    /// ' '
+    public static let space: Byte = 0x20
+
+    /// ,
+    public static let comma: Byte = 0x2C
+
+    /// [
+    public static let leftSquareBracket: Byte = 0x5B
+
+    /// ]
+    public static let rightSquareBracket: Byte = 0x5D
+}
+
+extension Byte {
+    /// Returns the `String` representation of this `Byte` (unicode scalar).
+    public var string: String {
+        String(Character(Unicode.Scalar(self)))
+    }
+}

--- a/Sources/Lytics/CodableRequestContainer.swift
+++ b/Sources/Lytics/CodableRequestContainer.swift
@@ -1,0 +1,52 @@
+//
+//  CodableRequestContainer.swift
+//
+//  Created by Mathew Gacy on 10/22/22.
+//
+
+import Foundation
+
+struct CodableRequestContainer: Codable {
+    var requests: [any RequestWrapping]
+
+    init(requests: [any RequestWrapping]) {
+        self.requests = requests
+    }
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.requests = []
+
+        let jsonDecoder = JSONDecoder()
+        while !container.isAtEnd {
+            let typeName = try container.decode(String.self)
+            guard let type = _typeByName(typeName) as? any Decodable.Type else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "\(typeName) is not decodable.")
+            }
+            let encodedValue = try container.decode(String.self)
+
+            if let value = try jsonDecoder.decode(type, from: Data(encodedValue.utf8)) as? (any RequestWrapping) {
+                self.requests.insert(value, at: 0)
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        for event in requests.reversed() {
+
+            func open<A: Encodable>(_: A.Type) throws -> Data {
+                try JSONEncoder().encode(event as! A)
+            }
+
+            try container.encode(_mangledTypeName(type(of: event)))
+
+            let string = try String(
+                decoding: _openExistential(type(of: event), do: open),
+                as: UTF8.self)
+            try container.encode(string)
+        }
+    }
+}

--- a/Sources/Lytics/Constants.swift
+++ b/Sources/Lytics/Constants.swift
@@ -1,0 +1,13 @@
+//
+//  Constants.swift
+//
+//  Created by Mathew Gacy on 10/20/22.
+//
+
+import Foundation
+
+enum Constants {
+    static let baseDirectory = "com.lytics.ios-sdk"
+    static let requestStorageDirectory = "requests"
+    static let requestStorageFilename = "requests"
+}

--- a/Sources/Lytics/DataUploadRequestBuilder.swift
+++ b/Sources/Lytics/DataUploadRequestBuilder.swift
@@ -27,13 +27,13 @@ extension DataUploadRequestBuilder {
                             let event = element.value.first!
                             data = try encoder.encode(event)
                         default:
-                            data = try element.value.reduce(into: Data.openBracket) { data, value in
+                            data = try element.value.reduce(into: Data([.leftSquareBracket])) { data, value in
                                 if data.count > 1 {
                                     data.append(.comma)
                                 }
                                 data.append(try encoder.encode(value))
                             }
-                            data.append(.closedBracket)
+                            data.append(.rightSquareBracket)
                         }
 
                         requests.append(

--- a/Sources/Lytics/EventPipeline.swift
+++ b/Sources/Lytics/EventPipeline.swift
@@ -10,32 +10,39 @@ import Foundation
 /// An event pipeline.
 struct EventPipeline {
     let logger: LyticsLogger
+    let sessionDidStart: (Millisecond) -> Bool
     let eventQueue: EventQueueing
     let uploader: Uploading
 
     init(
         logger: LyticsLogger,
+        sessionDidStart: @escaping (Millisecond) -> Bool,
         eventQueue: EventQueueing,
         uploader: Uploading
     ) {
         self.logger = logger
+        self.sessionDidStart = sessionDidStart
         self.eventQueue = eventQueue
         self.uploader = uploader
     }
 
     @usableFromInline
-    func event<P: Encodable>(_ event: Event<P>) async {
-        await eventQueue.enqueue(event)
+    func event<E: Encodable>(
+        stream: String,
+        timestamp: Millisecond,
+        name: String?,
+        event: E
+    ) async {
+        await eventQueue.enqueue(
+            Payload(
+                stream: stream,
+                timestamp: timestamp,
+                sessionDidStart: sessionDidStart(timestamp) ? 1 : nil,
+                event: event))
     }
 
-    @usableFromInline
-    func event<I: Encodable, A: Encodable>(_ identityEvent: IdentityEvent<I, A>) async {
-        await eventQueue.enqueue(identityEvent)
-    }
-
-    @usableFromInline
-    func event<C: Encodable>(_ consentEvent: ConsentEvent<C>) async {
-        await eventQueue.enqueue(consentEvent)
+    func dispatch() async {
+        await eventQueue.flush()
     }
 }
 
@@ -44,10 +51,25 @@ extension EventPipeline {
         logger: LyticsLogger,
         configuration: LyticsConfiguration
     ) -> Self {
-        let uploader = Uploader.live(logger: logger)
+        var requestCache: RequestCache?
+        do {
+            requestCache = try RequestCache.live()
+        } catch {
+            logger.error("Unable to create RequestCache: \(error)")
+        }
+
+        let uploader = Uploader.live(
+            logger: logger,
+            cache: requestCache,
+            maxRetryCount: configuration.maxRetryCount)
 
         return EventPipeline(
             logger: logger,
+            sessionDidStart: { timestamp in
+                let lastTimestamp = UserDefaults.standard.int64(for: .lastEventTimestamp)
+                UserDefaults.standard.set(timestamp, for: .lastEventTimestamp)
+                return timestamp - lastTimestamp > configuration.sessionDuration.milliseconds
+            },
             eventQueue: EventQueue.live(
                 logger: logger,
                 configuration: configuration,

--- a/Sources/Lytics/Events/ConsentEvent.swift
+++ b/Sources/Lytics/Events/ConsentEvent.swift
@@ -8,33 +8,20 @@ import AnyCodable
 import Foundation
 
 @usableFromInline
-struct ConsentEvent<C: Encodable>: StreamEvent {
-    var stream: String
-    var name: String?
+struct ConsentEvent<C: Encodable>: Encodable {
     var identifiers: [String: AnyCodable]?
     var attributes: [String: AnyCodable]?
     var consent: C?
 
     @usableFromInline
     init(
-        stream: String,
-        name: String? = nil,
         identifiers: [String: AnyCodable]? = nil,
         attributes: [String: AnyCodable]? = nil,
         consent: C? = nil
     ) {
-        self.stream = stream
-        self.name = name
         self.identifiers = identifiers
         self.attributes = attributes
         self.consent = consent
-    }
-
-    private enum CodingKeys: CodingKey {
-        case name
-        case identifiers
-        case attributes
-        case consent
     }
 }
 

--- a/Sources/Lytics/Events/Event.swift
+++ b/Sources/Lytics/Events/Event.swift
@@ -8,29 +8,17 @@ import AnyCodable
 import Foundation
 
 @usableFromInline
-struct Event<P: Encodable>: StreamEvent {
-    var stream: String
-    var name: String?
+struct Event<P: Encodable>: Encodable {
     var identifiers: [String: AnyCodable]?
     var properties: P?
 
     @usableFromInline
     init(
-        stream: String,
-        name: String? = nil,
         identifiers: [String: AnyCodable]? = nil,
         properties: P? = nil
     ) {
-        self.stream = stream
-        self.name = name
         self.identifiers = identifiers
         self.properties = properties
-    }
-
-    private enum CodingKeys: CodingKey {
-        case name
-        case identifiers
-        case properties
     }
 }
 

--- a/Sources/Lytics/Events/IdentityEvent.swift
+++ b/Sources/Lytics/Events/IdentityEvent.swift
@@ -7,24 +7,17 @@
 import Foundation
 
 @usableFromInline
-struct IdentityEvent<I: Encodable, A: Encodable>: StreamEvent {
-    var stream: String
-    var name: String?
+struct IdentityEvent<I: Encodable, A: Encodable>: Encodable {
     var identifiers: I?
     var attributes: A?
 
     @usableFromInline
-    init(stream: String, name: String? = nil, identifiers: I? = nil, attributes: A? = nil) {
-        self.stream = stream
-        self.name = name
+    init(
+        identifiers: I? = nil,
+        attributes: A? = nil
+    ) {
         self.identifiers = identifiers
         self.attributes = attributes
-    }
-
-    private enum CodingKeys: CodingKey {
-        case name
-        case identifiers
-        case attributes
     }
 }
 

--- a/Sources/Lytics/Events/Payload.swift
+++ b/Sources/Lytics/Events/Payload.swift
@@ -1,0 +1,61 @@
+//
+//  Payload.swift
+//
+//  Created by Mathew Gacy on 10/20/22.
+//
+
+import Foundation
+
+@usableFromInline
+struct Payload<E: Encodable>: StreamEvent {
+    var stream: String
+    var timestamp: Millisecond
+    var sessionDidStart: Int?
+    var name: String?
+    var event: E
+
+    @usableFromInline
+    init(
+        stream: String,
+        timestamp: Millisecond,
+        sessionDidStart: Int? = nil,
+        name: String? = nil,
+        event: E
+    ) {
+        self.stream = stream
+        self.timestamp = timestamp
+        self.sessionDidStart = sessionDidStart
+        self.name = name
+        self.event = event
+    }
+
+    @usableFromInline
+    init(
+        stream: String,
+        sessionTimestamp: (Millisecond, Int?),
+        name: String? = nil,
+        event: E
+    ) {
+        self.stream = stream
+        self.timestamp = sessionTimestamp.0
+        self.sessionDidStart = sessionTimestamp.1
+        self.name = name
+        self.event = event
+    }
+
+    @usableFromInline
+    func encode(to encoder: Encoder) throws {
+        var container: KeyedEncodingContainer<Payload<E>.CodingKeys> = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(self.timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(self.sessionDidStart, forKey: .sessionDidStart)
+        try container.encodeIfPresent(self.name, forKey: .name)
+        try event.encode(to: encoder)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case timestamp = "_ts"
+        case sessionDidStart = "_sesstart"
+        case name
+    }
+}

--- a/Sources/Lytics/Extensions/Data+Utils.swift
+++ b/Sources/Lytics/Extensions/Data+Utils.swift
@@ -7,7 +7,32 @@
 import Foundation
 
 extension Data {
-    static let openBracket = Data("[".utf8)
-    static let closedBracket = Data("]".utf8)
-    static let comma = Data(",".utf8)
+
+    /// Adds the elements of UTF-8-encoded JSON array data.
+    ///
+    /// This method will throw an error if either `Data` value does not begin and end with
+    /// the `[` and `]` control characters, respectively. It makes no guarantee as to the
+    /// contents of the data.
+    ///
+    /// - Parameter newArrayData: The data to add.
+    mutating func append(jsonArray newArrayData: inout Data) throws {
+        guard self.first == .leftSquareBracket,
+              self.last == .rightSquareBracket,
+              newArrayData.first == .leftSquareBracket,
+              newArrayData.last == .rightSquareBracket else {
+            throw LyticsError(reason: "Invalid data format")
+        }
+
+        // Handle empty array data
+        if count == 2 {
+            self = newArrayData
+            return
+        } else if newArrayData.count == 2 {
+            return
+        }
+
+        removeLast()
+        newArrayData[0] = .comma
+        append(newArrayData)
+    }
 }

--- a/Sources/Lytics/Extensions/FileManager+Utils.swift
+++ b/Sources/Lytics/Extensions/FileManager+Utils.swift
@@ -1,0 +1,59 @@
+//
+//  FileManager+Utils.swift
+//
+//  Created by Mathew Gacy on 10/22/22.
+//
+
+import Foundation
+
+extension FileManager {
+
+    /// Creates directory with the specified attributes for the given file.
+    /// - Parameters:
+    ///   - file: A file that specifies the parent directory to create.
+    ///   - attributes: The file attributes for the new directory.
+    func createDirectory(
+        for file: File,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        try createDirectory(
+            at: file.directory,
+            withIntermediateDirectories: true,
+            attributes: attributes)
+    }
+}
+
+extension FileManager {
+
+    /// Returns the URL of a subdirectory in the user's Caches directory.
+    /// - Parameter subdirectory: The optional name of a subdirectory in the Caches directory.
+    /// - Returns: The directory URL.
+    func temporaryURL(subdirectory: String? = nil) throws -> URL {
+        guard let baseURL = urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            throw StorageError.directoryNotFound(name: "Caches")
+        }
+
+        var directoryURL = baseURL.appendingPathComponent(Constants.baseDirectory)
+        if let subdirectory {
+            directoryURL.appendPathComponent(subdirectory, isDirectory: true)
+        }
+
+        return directoryURL
+    }
+
+    /// Returns the URL of a subdirectory in the user's Document directory.
+    /// - Parameter subDirectory: The optional name of a subdirectory in the Document directory.
+    /// - Returns: The directory URL.
+    func permanentURL(subdirectory: String? = nil) throws -> URL {
+        guard let baseURL = urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw StorageError.directoryNotFound(name: "Documents")
+        }
+
+        var directoryURL = baseURL.appendingPathComponent(Constants.baseDirectory)
+        if let subdirectory {
+            directoryURL.appendPathComponent(subdirectory, isDirectory: true)
+        }
+
+        return directoryURL
+    }
+}

--- a/Sources/Lytics/Extensions/TimeInterval+Utils.swift
+++ b/Sources/Lytics/Extensions/TimeInterval+Utils.swift
@@ -1,0 +1,13 @@
+//
+//  TimeInterval+Utils.swift
+//
+//  Created by Mathew Gacy on 10/21/22.
+//
+
+import Foundation
+
+public extension TimeInterval {
+    var milliseconds: Millisecond {
+        Millisecond((self * 1_000).rounded())
+    }
+}

--- a/Sources/Lytics/Extensions/URLSession+Utils.swift
+++ b/Sources/Lytics/Extensions/URLSession+Utils.swift
@@ -11,7 +11,7 @@ extension URLSession: RequestPerforming {
     /// Downloads the contents of a URL based on the specified request and delivers the response asynchronously.
     /// - Parameter request: The request to perform.
     /// - Returns: An asynchronously-delivered representation of the response.
-    func perform<T: RequestProtocol>(_ request: T) async throws -> Response<T.Resp> {
+    func perform<R>(_ request: Request<R>) async throws -> Response<R> {
         try await data(for: request.asURLRequest()) |> Response.init
     }
 }

--- a/Sources/Lytics/Extensions/UserDefaults+Utils.swift
+++ b/Sources/Lytics/Extensions/UserDefaults+Utils.swift
@@ -1,0 +1,55 @@
+//
+//  UserDefaults+Utils.swift
+//
+//  Created by Mathew Gacy on 10/20/22.
+//
+
+import Foundation
+
+// MARK: - Read
+extension UserDefaults {
+
+    func bool(for key: UserDefaultsKey) -> Bool {
+        bool(forKey: key.rawValue)
+    }
+
+    func dictionary(for key: UserDefaultsKey) -> [String: Any]? {
+        dictionary(forKey: key.rawValue)
+    }
+
+    func int64(for key: UserDefaultsKey) -> Int64 {
+        object(forKey: key.rawValue) as? Int64 ?? 0
+    }
+
+    func integer(for key: UserDefaultsKey) -> Int {
+        integer(forKey: key.rawValue)
+    }
+
+    func string(for key: UserDefaultsKey) -> String? {
+        string(forKey: key.rawValue)
+    }
+}
+
+// MARK: - Write
+extension UserDefaults {
+
+    func set(_ value: Bool, for key: UserDefaultsKey) {
+        set(value, forKey: key.rawValue)
+    }
+
+    func set(_ value: [String: Any], for key: UserDefaultsKey) {
+        set(value, forKey: key.rawValue)
+    }
+
+    func set(_ value: Int64, for key: UserDefaultsKey) {
+        set(value, forKey: key.rawValue)
+    }
+
+    func set(_ value: Int, for key: UserDefaultsKey) {
+        set(value, forKey: key.rawValue)
+    }
+
+    func set(_ value: String, for key: UserDefaultsKey) {
+        set(value, forKey: key.rawValue)
+    }
+}

--- a/Sources/Lytics/LyticsConfiguration.swift
+++ b/Sources/Lytics/LyticsConfiguration.swift
@@ -41,10 +41,13 @@ public struct LyticsConfiguration: Equatable {
     /// Set to `0` to disable.
     public var maxQueueSize: Int = 10
 
+    /// The max number of times to try and resend an event on failure.
+    public var maxRetryCount: Int = 3
+
     /// Session timeout in seconds.
     ///
     /// This is the period from when the app enters the background and the session expires, starting a new session.
-    public var sessionDuration: Double = 1200
+    public var sessionDuration: TimeInterval = 1200
 
     /// Enable sandbox mode which adds a "sandbox" flag to all outbound events. This flag then enables those events to be
     /// processed in an alternative way or skipped entirely upon delivery to the Lytics collection APIs.

--- a/Sources/Lytics/LyticsError.swift
+++ b/Sources/Lytics/LyticsError.swift
@@ -1,0 +1,19 @@
+//
+//  LyticsError.swift
+//
+//  Created by Mathew Gacy on 10/21/22.
+//
+
+import Foundation
+
+struct LyticsError: Error {
+    var reason: String
+    var underlyingError: Error?
+}
+
+extension LyticsError {
+    init(_ error: Error) {
+        self.reason = error.localizedDescription
+        self.underlyingError = error
+    }
+}

--- a/Sources/Lytics/LyticsUser.swift
+++ b/Sources/Lytics/LyticsUser.swift
@@ -31,8 +31,8 @@ public struct LyticsUser: Codable, Equatable {
     ///   - attributes: Additional information about a user.
     public init(
         userType: UserType = .anonymous,
-        identifiers: [String : AnyCodable] = [:],
-        attributes: [String : AnyCodable] = [:]
+        identifiers: [String: AnyCodable] = [:],
+        attributes: [String: AnyCodable] = [:]
     ) {
         self.userType = userType
         self.identifiers = identifiers
@@ -48,8 +48,8 @@ public extension LyticsUser {
     ///   - attributes: Additional information about a user.
     init(
         userType: UserType = .anonymous,
-        identifiers: [String : Any] = [:],
-        attributes: [String : Any] = [:]
+        identifiers: [String: Any] = [:],
+        attributes: [String: Any] = [:]
     ) {
         self.userType = userType
         self.identifiers = identifiers.mapValues(AnyCodable.init(_:))

--- a/Sources/Lytics/Millisecond.swift
+++ b/Sources/Lytics/Millisecond.swift
@@ -1,0 +1,16 @@
+//
+//  Millisecond.swift
+//
+//  Created by Mathew Gacy on 10/21/22.
+//
+
+import Foundation
+
+/// The number of milliseconds between 00:00:00 UTC on 1 January 1970 and an event.
+public typealias Millisecond = Int64
+
+extension Millisecond {
+    static var minute: Self {
+        60_000
+    }
+}

--- a/Sources/Lytics/Networking/RequestCache.swift
+++ b/Sources/Lytics/Networking/RequestCache.swift
@@ -1,0 +1,61 @@
+//
+//  RequestCache.swift
+//
+//  Created by Mathew Gacy on 10/18/22.
+//
+
+import Foundation
+
+/// Stores a collection of requests.
+struct RequestCache: RequestCaching {
+    let storage: Storage
+
+    init(storage: Storage) throws {
+        self.storage = storage
+    }
+
+    /// Caches a collection of wrapped requests.
+    /// - Parameter requests: The wrapped requests to cache.
+    func cache(_ requests: [any RequestWrapping]) throws {
+        guard requests.isNotEmpty else {
+            return
+        }
+
+        var requestData = try JSONEncoder()
+            .encode(
+                CodableRequestContainer(requests: requests))
+
+        let currentData = try storage.read()
+        if var currentData, currentData.count > 2 {
+            try currentData.append(jsonArray: &requestData)
+            try storage.write(currentData)
+        } else {
+            try storage.write(requestData)
+        }
+    }
+
+    /// Loads cached requuests.
+    /// - Returns: The cached requests.
+    func load() throws -> [any RequestWrapping]? {
+        guard let data = try storage.read() else {
+            return nil
+        }
+
+        let decoded = try JSONDecoder()
+            .decode(CodableRequestContainer.self, from: data)
+        return decoded.requests
+    }
+
+    /// Deletes all cached requests.
+    func deleteAll() throws {
+        try storage.clear()
+    }
+}
+
+extension RequestCache {
+    static func live() throws -> Self {
+        try .init(
+            storage: try .live(
+                file: try .requests()))
+    }
+}

--- a/Sources/Lytics/Protocols/RequestCaching.swift
+++ b/Sources/Lytics/Protocols/RequestCaching.swift
@@ -1,0 +1,22 @@
+//
+//  RequestCaching.swift
+//
+//  Created by Mathew Gacy on 10/18/22.
+//
+
+import Foundation
+
+/// A type capable of storing requests.
+protocol RequestCaching {
+
+    /// Caches a collection of wrapped requests.
+    /// - Parameter requests: The wrapped requests to cache.
+    func cache(_ requests: [any RequestWrapping]) throws
+
+    /// Loads cached requuests.
+    /// - Returns: The cached requests.
+    func load() throws -> [any RequestWrapping]?
+
+    /// Deletes all cached requests.
+    func deleteAll() throws
+}

--- a/Sources/Lytics/Protocols/RequestPerforming.swift
+++ b/Sources/Lytics/Protocols/RequestPerforming.swift
@@ -12,5 +12,5 @@ protocol RequestPerforming {
     /// Downloads the contents of a URL based on the specified request and delivers the response asynchronously.
     /// - Parameter request: The request to perform.
     /// - Returns: An asynchronously-delivered representation of the response.
-    func perform<T: RequestProtocol>(_ request: T) async throws -> Response<T.Resp>
+    func perform<R>(_ request: Request<R>) async throws -> Response<R>
 }

--- a/Sources/Lytics/Protocols/RequestWrapping.swift
+++ b/Sources/Lytics/Protocols/RequestWrapping.swift
@@ -1,0 +1,25 @@
+//
+//  RequestWrapping.swift
+//
+//  Created by Mathew Gacy on 10/16/22.
+//
+
+import Foundation
+
+/// A type that wraps a request.
+protocol RequestWrapping<Resp>: Codable {
+    /// The type of the wrapped request's response.
+    associatedtype Resp: Codable
+
+    /// A unique value identifying the wrapped request.
+    var id: UUID { get }
+
+    /// The wrapped request.
+    var request: Request<Resp> { get }
+
+    /// A count of attempts to upload the wrapped requeust.
+    var retryCount: Int { get set }
+
+    /// The task to upload the wrapped request.
+    var uploadTask: Task<Void, Never>? { get set }
+}

--- a/Sources/Lytics/Protocols/Uploading.swift
+++ b/Sources/Lytics/Protocols/Uploading.swift
@@ -12,4 +12,7 @@ protocol Uploading: Actor {
     /// Uploads requests to the Lytics API.
     /// - Parameter request: The requests to upload.
     func upload<T: Codable>(_ request: [Request<T>])
+
+    /// Stores pending requests and cancels their upload tasks.
+    func storeRequests()
 }

--- a/Sources/Lytics/Protocols/UserManaging.swift
+++ b/Sources/Lytics/Protocols/UserManaging.swift
@@ -8,6 +8,7 @@ import AnyCodable
 import Foundation
 
 /// A type that manages user identifiers and attributes.
+@usableFromInline
 protocol UserManaging: Actor {
 
     /// The user identifiers.
@@ -39,4 +40,7 @@ protocol UserManaging: Actor {
     /// - Parameter userUpdate: The update.
     /// - Returns: The updated user.
     func update<A: Encodable, I: Encodable>(with userUpdate: UserUpdate<A, I>) throws -> LyticsUser
+
+    /// Clear all stored user information.
+    func clear()
 }

--- a/Sources/Lytics/RequestFailureHandler.swift
+++ b/Sources/Lytics/RequestFailureHandler.swift
@@ -1,0 +1,71 @@
+//
+//  RequestFailureHandler.swift
+//
+//  Created by Mathew Gacy on 10/16/22.
+//
+
+import Foundation
+
+struct RequestFailureHandler {
+
+    enum Strategy: Equatable {
+        /// Discard a request that failed due to an unrecoverable error.
+        case discard(_ reason: String)
+        /// Retry the request in `delay` seconds.
+        case retry(_ delay: TimeInterval)
+        /// Store the request to retry later.
+        case store
+    }
+
+    struct RetryConfiguration {
+        let maxRetryCount: Int
+        let initialDelay: TimeInterval
+        let delayMultiplier: Double
+    }
+
+    let configuration: RetryConfiguration
+
+    func strategy(for error: Error, retryCount: Int) -> Strategy {
+        if error is DecodingError {
+            return .discard("Invalid response value")
+        }
+
+        if retryCount < configuration.maxRetryCount {
+            let delay = Self.calculateDelay(
+                currentAttempt: retryCount + 1,
+                initialDelay: configuration.initialDelay,
+                delayMultiplier: configuration.delayMultiplier)
+
+            return .retry(delay)
+        } else {
+            return .store
+        }
+    }
+
+    private static func calculateDelay(
+        currentAttempt: Int,
+        initialDelay: TimeInterval,
+        delayMultiplier: Double
+    ) -> TimeInterval {
+        currentAttempt == 1
+        ? initialDelay
+        : initialDelay * pow(1 + delayMultiplier, Double(currentAttempt - 1))
+    }
+}
+
+extension RequestFailureHandler.RetryConfiguration {
+    static func live(maxRetryCount: Int) -> Self {
+        .init(maxRetryCount: maxRetryCount,
+              initialDelay: 10,
+              delayMultiplier: 1
+        )
+    }
+}
+
+extension RequestFailureHandler {
+    static func live(maxRetryCount: Int) -> Self {
+        .init(
+            configuration: .live(
+                maxRetryCount: maxRetryCount))
+    }
+}

--- a/Sources/Lytics/Storage/File.swift
+++ b/Sources/Lytics/Storage/File.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//
+//  Created by Mathew Gacy on 10/19/22.
+//
+
+import Foundation
+
+struct File {
+    let directory: URL
+    let name: String
+
+    var url: URL {
+        directory.appendingPathComponent(name)
+    }
+
+    var path: String {
+        url.path
+    }
+
+    init(directory: URL, name: String) {
+        self.directory = directory
+        self.name = name
+    }
+}
+
+extension File {
+    static func requests() throws -> Self {
+        .init(
+            directory: try FileManager.default.permanentURL(
+                subdirectory: Constants.requestStorageDirectory),
+            name: Constants.requestStorageFilename)
+    }
+}

--- a/Sources/Lytics/Storage/Storage.swift
+++ b/Sources/Lytics/Storage/Storage.swift
@@ -1,0 +1,71 @@
+//
+//  Storage.swift
+//
+//  Created by Mathew Gacy on 10/23/22.
+//
+
+import Foundation
+
+struct Storage {
+    var write: (Data) throws -> Void
+    var read: () throws -> Data?
+    var clear: () throws -> Void
+}
+
+extension Storage {
+    func save<T: Encodable>(_ object: T, encodingWith encoder: JSONEncoder = .init()) throws {
+        do {
+            let data = try encoder.encode(object)
+            try write(data)
+        } catch {
+            throw StorageError(underlyingError: error)
+        }
+    }
+
+    func read<T: Decodable>(decodingWith decoder: JSONDecoder = .init()) throws -> T? {
+        guard let data = try read() else {
+            return nil
+        }
+        do {
+            let object = try decoder.decode(T.self, from: data)
+            return object
+        } catch {
+            throw StorageError(underlyingError: error)
+        }
+    }
+}
+
+extension Storage {
+    static func live(file: File) throws -> Self {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(for: file)
+
+        return Storage(
+            write: { data in
+                do {
+                    try fileManager.createDirectory(at: file.directory, withIntermediateDirectories: true)
+                    try data.write(to: file.url, options: .atomic)
+                } catch {
+                    throw StorageError.file(path: file.path, error: error)
+                }
+            },
+            read: {
+                do {
+                    return try Data(contentsOf: file.url)
+                } catch CocoaError.Code.fileReadNoSuchFile {
+                    return nil
+                } catch {
+                    throw StorageError.file(path: file.path, error: error)
+                }
+            },
+            clear: {
+                do {
+                    try fileManager.removeItem(at: file.url)
+                } catch CocoaError.Code.fileNoSuchFile {
+                    return
+                } catch {
+                    throw StorageError.file(path: file.path, error: error)
+                }
+            })
+    }
+}

--- a/Sources/Lytics/Storage/StorageError.swift
+++ b/Sources/Lytics/Storage/StorageError.swift
@@ -1,0 +1,40 @@
+//
+//  StorageError.swift
+//
+//  Created by Mathew Gacy on 10/23/22.
+//
+
+import Foundation
+
+enum StorageError: Error {
+    case encoding(EncodingError)
+    case decoding(DecodingError)
+    case file(path: String, error: Error)
+    case directoryNotFound(name: String)
+
+    init(underlyingError: Error, path: String = "") {
+        switch underlyingError {
+        case let error as EncodingError:
+            self = .encoding(error)
+        case let error as DecodingError:
+            self = .decoding(error)
+        case let error as StorageError:
+            self = error
+        default:
+            self = .file(path: path, error: underlyingError)
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case let .encoding(error):
+            return error.localizedDescription
+        case let .decoding(error):
+            return error.localizedDescription
+        case let .file(path: path, error: error):
+            return "Operation on \(path) failed: \(error.localizedDescription)"
+        case let .directoryNotFound(name):
+            return "Unable to find \(name) directory."
+        }
+    }
+}

--- a/Sources/Lytics/Uploader.swift
+++ b/Sources/Lytics/Uploader.swift
@@ -6,34 +6,223 @@
 
 import Foundation
 
+/// Uploads requests to the Lytics API.
 actor Uploader: Uploading {
+
+    /// A wrapper for an in-progress request.
+    final class PendingRequest<R: Codable>: Codable, RequestWrapping {
+
+        /// A unique value identifying the wrapped request.
+        let id: UUID
+
+        /// The wrapped request.
+        let request: Request<R>
+
+        /// A count of attempts to upload the wrapped requeust.
+        var retryCount: Int = 0
+
+        /// The task to upload the wrapped request.
+        var uploadTask: Task<Void, Never>?
+
+        init(
+            id: UUID = .init(),
+            request: Request<R>,
+            retryCount: Int = 0,
+            uploadTask: Task<Void, Never>? = nil
+        ) {
+            self.id = id
+            self.request = request
+            self.retryCount = retryCount
+            self.uploadTask = uploadTask
+        }
+
+        init(from decoder: Decoder) throws {
+            let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(
+                keyedBy: CodingKeys.self)
+
+            self.id = try container.decode(UUID.self, forKey: .id)
+            self.request = try container.decode(Request<R>.self, forKey: .request)
+            self.retryCount = 0
+            self.uploadTask = nil
+        }
+
+        final func encode(to encoder: Encoder) throws {
+            var container: KeyedEncodingContainer<CodingKeys> = encoder.container(
+                keyedBy: CodingKeys.self)
+
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.request, forKey: .request)
+        }
+
+        private enum CodingKeys: CodingKey {
+            case id
+            case request
+        }
+    }
+
     private let logger: LyticsLogger
     private let decoder: JSONDecoder
     private let requestPerformer: RequestPerforming
+    private let errorHandler: RequestFailureHandler
+    private let cache: RequestCaching?
+    private var pendingRequests: [UUID: any RequestWrapping]
+
+    /// A Boolean value that indicates whether any requests passed to `upload(_:)` should be upload or stored immediately.
+    var shouldSend: Bool
+
+    /// The number of requests waiting to be uploaded.
+    var pendingRequestCount: Int {
+        pendingRequests.count
+    }
 
     init(
         logger: LyticsLogger,
         decoder: JSONDecoder = .init(),
-        requestPerformer: RequestPerforming
+        requestPerformer: RequestPerforming,
+        errorHandler: RequestFailureHandler,
+        cache: RequestCaching?,
+        shouldSend: Bool = true
     ) {
         self.logger = logger
         self.decoder = decoder
         self.requestPerformer = requestPerformer
+        self.errorHandler = errorHandler
+        self.cache = cache
+        self.pendingRequests = [:]
+        self.shouldSend = shouldSend
     }
 
     /// Uploads requests to the Lytics API.
-    /// - Parameter request: The requests to upload.
-    func upload<T: Codable>(_ request: [Request<T>]) {
-        // ...
+    /// - Parameter requests: The requests to upload.
+    func upload<T: Codable>(_ requests: [Request<T>]) {
+        guard shouldSend else {
+            let wrapped: [any RequestWrapping] = requests.map { PendingRequest(request: $0) }
+            do {
+                try cache?.cache(wrapped)
+            } catch {
+                logger.error("Unable to cache \(requests): \(error)")
+            }
+
+            return
+        }
+
+        for request in requests {
+            let id = UUID()
+            let wrapper = PendingRequest(id: id, request: request)
+            pendingRequests[id] = wrapper
+
+            wrapper.uploadTask = Task.detached(priority: .utility) { [weak self] in
+                await self?.send(request: request, id: id)
+            }
+        }
+    }
+
+    /// Stores pending requests and cancels their upload tasks.
+    func storeRequests() {
+        shouldSend = false
+        pendingRequests.forEach { $0.value.uploadTask?.cancel() }
+
+        for (id, wrapper) in pendingRequests {
+            pendingRequests[id] = nil
+            openAndCache(wrapper)
+        }
+    }
+}
+
+private extension Uploader {
+
+    /// Removes a wrapped request from ``requests`` and cancels its task.
+    /// - Parameter id: The unique value identifying the wrapper of the request to be removed.
+    func remove(id: UUID) {
+        pendingRequests[id]?.uploadTask?.cancel()
+        pendingRequests[id] = nil
+    }
+
+    /// Sends a request to the Lytics API and handle any errors.
+    /// - Parameters:
+    ///   - request: The request the send.
+    ///   - id: The unique value identifying the request's wrapper.
+    func send<R: Codable>(request: Request<R>, id: UUID) async {
+        do {
+            let response = try await requestPerformer
+                .perform(request)
+                .validate()
+                .decode()
+
+            logger.debug("\(response)")
+
+            remove(id: id)
+        } catch {
+            handleError(error, id: id)
+        }
+    }
+}
+
+private extension Uploader {
+
+    // The following generic methods are used to open an existential element of ``requests`` and access its underlying request.
+
+    /// Sends a request wrapper's request.
+    /// - Parameter wrapper: The instance wrapping the request to send.
+    func openAndSend<R: RequestWrapping>(_ wrapper: R) async {
+        await send(request: wrapper.request, id: wrapper.id)
+    }
+
+    /// Caches a request wrapper's request.
+    /// - Parameter wrapper: The instance wrapping the request to cache.
+    func openAndCache<T: RequestWrapping>(_ wrapper: T) {
+        do {
+            try cache?.cache([wrapper])
+        } catch {
+            logger.error("Unable to cache \(wrapper): \(error)")
+        }
+    }
+
+    /// Handles a failure to send a request by retrying it, storing it, or giving based on the specific error encountered.
+    /// - Parameters:
+    ///   - error: The error the handle.
+    ///   - id: The unique value identifying the wrapper of the request to which the error is associated.
+    func handleError(_ error: Error, id: UUID) {
+        logger.error("Request error for \(id): \(error.localizedDescription)")
+        guard var wrapper = pendingRequests[id] else {
+            logger.debug("Unable to find request \(id)")
+            return
+        }
+
+        switch errorHandler.strategy(for: error, retryCount: wrapper.retryCount) {
+        case .discard(let reason):
+            logger.info("Unable to recover from \(error) uploading request \(wrapper.id): \(reason)")
+            remove(id: id)
+
+        case .retry(let delay):
+            logger.debug("Retrying request \(wrapper.id) in \(delay)")
+            wrapper.retryCount += 1
+            wrapper.uploadTask = Task.delayed(byTimeInterval: delay) { [weak self] in
+                guard let wrapper = await self?.pendingRequests[id] else {
+                    self?.logger.debug("Unable to find request \(id)")
+                    return
+                }
+
+                await self?.openAndSend(wrapper)
+            }
+
+        case .store:
+            remove(id: id)
+            openAndCache(wrapper)
+        }
     }
 }
 
 extension Uploader {
     static func live(
-        logger: LyticsLogger
+        logger: LyticsLogger,
+        cache: RequestCaching?,
+        maxRetryCount: Int
     ) -> Uploader {
         .init(
             logger: logger,
-            requestPerformer: URLSession.live)
+            requestPerformer: URLSession.live,
+            errorHandler: .live(maxRetryCount: maxRetryCount),
+            cache: cache)
     }
 }

--- a/Sources/Lytics/UserDefaultsKey.swift
+++ b/Sources/Lytics/UserDefaultsKey.swift
@@ -1,0 +1,23 @@
+//
+//  UserDefaultsKey.swift
+//
+//  Created by Mathew Gacy on 10/22/22.
+//
+
+import Foundation
+
+/// Keys used to store data in `UserDefaults`.
+enum UserDefaultsKey: String {
+
+    /// The most recent event timestamp.
+    case lastEventTimestamp = "last_event_timestamp"
+
+    /// The most recent release or version number.
+    case lastVersionNumber = "last_version_number"
+
+    /// The current user attributes.
+    case userAttributes = "user_attributes"
+
+    /// The current user identifiers.
+    case userIdentifiers = "user_identifiers"
+}

--- a/Sources/Lytics/UserManager.swift
+++ b/Sources/Lytics/UserManager.swift
@@ -11,6 +11,7 @@ import Foundation
 @usableFromInline
 actor UserManager: UserManaging {
     private let encoder: JSONEncoder
+    private let storage: UserStorage
 
     /// The user identifiers.
     @usableFromInline private(set) var identifiers: [String: Any]
@@ -19,22 +20,21 @@ actor UserManager: UserManaging {
     @usableFromInline private(set) var attributes: [String: Any]
 
     /// The current user.
-    var user: LyticsUser {
+    @usableFromInline var user: LyticsUser {
         .init(
             userType: .anonymous,
             identifiers: identifiers.mapValues(AnyCodable.init(_:)),
             attributes: attributes.mapValues(AnyCodable.init(_:)))
     }
 
-    @usableFromInline
     init(
-        encoder: JSONEncoder = .init(),
-        identifiers: [String: Any] = [:],
-        attributes: [String: Any] = [:]
+        encoder: JSONEncoder,
+        storage: UserStorage
     ) {
         self.encoder = encoder
-        self.identifiers = identifiers
-        self.attributes = attributes
+        self.storage = storage
+        self.identifiers = storage.identifiers()
+        self.attributes = storage.attributes()
     }
 
     @discardableResult
@@ -44,6 +44,7 @@ actor UserManager: UserManaging {
     /// - Returns: The updated identifiers.
     func updateIdentifiers<T: Encodable>(with other: T) throws -> [String: Any] {
         identifiers = identifiers.deepMerging(try(convert(other)))
+        storage.storeIdentifiers(identifiers)
         return identifiers
     }
 
@@ -54,6 +55,7 @@ actor UserManager: UserManaging {
     /// - Returns: The updated attributes.
     func updateAttributes<T: Encodable>(with other: T) throws -> [String: Any] {
         attributes = attributes.deepMerging(try convert(other))
+        storage.storeAttributes(attributes)
         return attributes
     }
 
@@ -93,6 +95,13 @@ actor UserManager: UserManaging {
         return LyticsUser(identifiers: updatedIdentifiers, attributes: updatedAttributes)
     }
 
+    @usableFromInline
+    /// Clear all stored user information.
+    func clear() {
+        storage.storeAttributes([:])
+        storage.storeIdentifiers([:])
+    }
+
     private func convert<T: Encodable>(_ value: T) throws -> [String: Any] {
         let data = try encoder.encode(value)
         guard let dictionary = try JSONSerialization.jsonObject(
@@ -107,4 +116,18 @@ actor UserManager: UserManaging {
         }
         return dictionary
     }
+}
+
+extension UserManager {
+    @usableFromInline static var live: Self {
+        .init(
+            encoder: JSONEncoder(),
+            storage: .live)
+    }
+
+    #if DEBUG
+    static let mock = UserManager(
+        encoder: JSONEncoder(),
+        storage: .mock)
+    #endif
 }

--- a/Sources/Lytics/UserStorage.swift
+++ b/Sources/Lytics/UserStorage.swift
@@ -1,0 +1,42 @@
+//
+//  UserStorage.swift
+//
+//  Created by Mathew Gacy on 10/21/22.
+//
+
+import Foundation
+
+struct UserStorage {
+    var attributes: () -> [String: Any]
+    var identifiers: () -> [String: Any]
+    var storeAttributes: ([String: Any]) -> Void
+    var storeIdentifiers: ([String: Any]) -> Void
+}
+
+extension UserStorage {
+    static var live: Self {
+        let userDefaults = UserDefaults.standard
+
+        return .init(
+            attributes: {
+                userDefaults.dictionary(for: .userAttributes) ?? [:]
+            },
+            identifiers: {
+                userDefaults.dictionary(for: .userIdentifiers) ?? [:]
+            },
+            storeAttributes: { attributes in
+                userDefaults.set(attributes, for: .userAttributes)
+            },
+            storeIdentifiers: { identifiers in
+                userDefaults.set(identifiers, for: .userIdentifiers)
+            })
+    }
+
+    #if DEBUG
+    static let mock = UserStorage(
+        attributes: { [:] },
+        identifiers: { [:] },
+        storeAttributes: { _ in },
+        storeIdentifiers: { _ in })
+    #endif
+}

--- a/Tests/LyticsTests/CodableRequestContainerTests.swift
+++ b/Tests/LyticsTests/CodableRequestContainerTests.swift
@@ -1,0 +1,103 @@
+//
+//  CodableRequestContainerTests.swift
+//
+//  Created by Mathew Gacy on 10/18/22.
+//
+
+@testable import Lytics
+import AnyCodable
+import XCTest
+
+final class CodableRequestContainerTests: XCTestCase {
+    let identityEvent = Mock.payload(
+        stream: Mock.stream(.one),
+        timestamp: Mock.timestamp(.one),
+        sessionDidStart: 1,
+        name: Mock.name(.one),
+        event: IdentityEvent(
+            identifiers: User1.identifiers,
+            attributes: User1.attributes))
+
+    var identityEventDictionary: [String: Any] {
+        var payload = Mock.payloadDictionary(
+            stream: Mock.stream(.one),
+            timestamp: Mock.timestamp(.one),
+            sessionDidStart: 1,
+            name: Mock.name(.one))
+
+        return Mock.identityEventDictionary(
+            payload: &payload,
+            identifiers: User1.anyIdentifiers,
+            attributes: User1.anyAttributes)
+    }
+
+    let consentEvent = Mock.payload(
+        stream: Mock.stream(.two),
+        timestamp: Mock.timestamp(.two),
+        name: Mock.name(.two),
+        event: ConsentEvent(
+            identifiers: User1.identifiers,
+            consent: TestConsent.user1))
+
+    var consentEventDictionary: [String: Any] {
+        var payload = Mock.payloadDictionary(
+            stream: Mock.stream(.two),
+            timestamp: Mock.timestamp(.two),
+            name: Mock.name(.two))
+
+        return Mock.consentEventDictionary(
+            payload: &payload,
+            identifiers: User1.anyIdentifiers,
+            consent: [
+                "document": TestConsent.user1.document,
+                "timestamp": TestConsent.user1.timestamp,
+                "consented": TestConsent.user1.consented
+            ])
+    }
+
+    var events: [String: [any StreamEvent]] {
+        [
+            Mock.stream(.one): [
+                identityEvent
+            ],
+            Mock.stream(.two): [
+                consentEvent
+            ]
+        ]
+    }
+
+    func testEncodeAndDecode() throws {
+        let requestBuilder = DataUploadRequestBuilder.live(apiKey: Mock.apiKey)
+        let wrappedRequests = try requestBuilder
+            .requests(events)
+            .map { Uploader.PendingRequest(request: $0) }
+
+        // Encode
+        let container = CodableRequestContainer(requests: wrappedRequests)
+        let data = try JSONEncoder().encode(container)
+
+        let string = String(decoding: data, as: UTF8.self)
+        print("\(string)\n")
+
+        // Decoded
+        let decoded = try JSONDecoder().decode(CodableRequestContainer.self, from: data)
+        XCTAssertEqual(decoded.requests.count, 2)
+
+        let wrapper1 = decoded.requests.first! as! Uploader.PendingRequest<DataUploadResponse>
+        let body1 = try JSONSerialization.jsonObject(with: wrapper1.request.body!) as! [String: Any]
+
+        let wrapper2 = decoded.requests.last! as! Uploader.PendingRequest<DataUploadResponse>
+        let body2 = try JSONSerialization.jsonObject(with: wrapper2.request.body!) as! [String: Any]
+
+        switch wrapper1.request.url.lastPathComponent {
+        case Mock.stream(.one):
+            Assert.identityEventEquality(body1, expected: identityEventDictionary)
+            Assert.consentEventEquality(body2, expected: consentEventDictionary)
+        case Mock.stream(.two):
+            Assert.identityEventEquality(body2, expected: identityEventDictionary)
+            Assert.consentEventEquality(body1, expected: consentEventDictionary)
+        default:
+            XCTFail("Request URLs do not match expectations")
+        }
+    }
+}

--- a/Tests/LyticsTests/DataUploadRequestBuilderTests.swift
+++ b/Tests/LyticsTests/DataUploadRequestBuilderTests.swift
@@ -26,18 +26,23 @@ final class DataUploadRequestBuilderTests: XCTestCase {
     func testEncodeSingle() throws {
         let events: [String: [any StreamEvent]] = [
             stream1: [
-                IdentityEvent(
+                Mock.payload(
                     stream: stream1,
+                    timestamp: Mock.timestamp(.one),
+                    sessionDidStart: 1,
                     name: name1,
-                    identifiers: User1.identifiers,
-                    attributes: User1.attributes)
+                    event: IdentityEvent(
+                        identifiers: User1.identifiers,
+                        attributes: User1.attributes))
             ],
             stream2: [
-                ConsentEvent(
-                   stream: stream2,
-                   name: name2,
-                   identifiers: User1.identifiers,
-                   consent: TestConsent.user1)
+                Mock.payload(
+                    stream: stream2,
+                    timestamp: Mock.timestamp(.two),
+                    name: name2,
+                    event: ConsentEvent(
+                        identifiers: User1.identifiers,
+                        consent: TestConsent.user1))
             ]
         ]
 
@@ -54,16 +59,21 @@ final class DataUploadRequestBuilderTests: XCTestCase {
     func testEncodeMultiple() throws {
         let events: [String: [any StreamEvent]] = [
             stream1: [
-                IdentityEvent(
+                Mock.payload(
                     stream: stream1,
+                    timestamp: Mock.timestamp(.one),
+                    sessionDidStart: 1,
                     name: name1,
-                    identifiers: User1.identifiers,
-                    attributes: User1.attributes),
-                ConsentEvent(
-                   stream: stream2,
-                   name: name2,
-                   identifiers: User1.identifiers,
-                   consent: TestConsent.user1)
+                    event: IdentityEvent(
+                        identifiers: User1.identifiers,
+                        attributes: User1.attributes)),
+                Mock.payload(
+                    stream: stream2,
+                    timestamp: Mock.timestamp(.two),
+                    name: name2,
+                    event: ConsentEvent(
+                        identifiers: User1.identifiers,
+                        consent: TestConsent.user1))
             ]
         ]
 
@@ -99,6 +109,9 @@ extension DataUploadRequestBuilderTests {
     func assertOnIdentityEvent(_ object: [String: Any]) {
         XCTAssertEqual(object["name"] as! String, name1)
 
+        XCTAssertEqual(object["_ts"] as! Int64, Mock.timestamp(.one))
+        XCTAssertEqual(object["_sesstart"] as! Int, 1)
+
         let identifiers1 = object["identifiers"] as! [String: Any]
         XCTAssertEqual(identifiers1["email"] as! String, User1.email)
         XCTAssertEqual(identifiers1["userID"] as! Int, User1.userID)
@@ -113,6 +126,8 @@ extension DataUploadRequestBuilderTests {
 
     func assertOnConsentEvent(_ object: [String: Any]) {
         XCTAssertEqual(object["name"] as! String, name2)
+
+        XCTAssertEqual(object["_ts"] as! Int64, Mock.timestamp(.two))
 
         let identifiers2 = object["identifiers"] as! [String: Any]
         XCTAssertEqual(identifiers2["email"] as! String, User1.email)

--- a/Tests/LyticsTests/EventQueueTests.swift
+++ b/Tests/LyticsTests/EventQueueTests.swift
@@ -32,10 +32,10 @@ final class EventQueueTests: XCTestCase {
 
         buildExpectation.isInverted = true
 
-        await sut.enqueue(Mock.consentEvent)
-        await sut.enqueue(Mock.event)
+        await sut.enqueue(Mock.payload(event: Mock.consentEvent))
+        await sut.enqueue(Mock.payload(event: Mock.event))
         buildExpectation.isInverted = false
-        await sut.enqueue(Mock.identityEvent)
+        await sut.enqueue(Mock.payload(event: Mock.identityEvent))
 
         await waitForExpectations(timeout: 1.0)
     }
@@ -56,9 +56,9 @@ final class EventQueueTests: XCTestCase {
             requestBuilder: requestBuilder,
             upload: { _ in })
 
-        await sut.enqueue(Mock.consentEvent)
-        await sut.enqueue(Mock.event)
-        await sut.enqueue(Mock.identityEvent)
+        await sut.enqueue(Mock.payload(event: Mock.consentEvent))
+        await sut.enqueue(Mock.payload(event: Mock.event))
+        await sut.enqueue(Mock.payload(event: Mock.identityEvent))
         await waitForExpectations(timeout: 2.0)
     }
 
@@ -78,7 +78,7 @@ final class EventQueueTests: XCTestCase {
             requestBuilder: requestBuilder,
             upload: { _ in })
 
-        await sut.enqueue(Mock.consentEvent)
+        await sut.enqueue(Mock.payload(event: Mock.consentEvent))
         await sut.flush()
 
         await waitForExpectations(timeout: 1.0)
@@ -102,7 +102,7 @@ final class EventQueueTests: XCTestCase {
         let hasTimerTaskBefore = await sut.hasTimerTask
         XCTAssert(!hasTimerTaskBefore)
 
-        await sut.enqueue(Mock.event)
+        await sut.enqueue(Mock.payload(event: Mock.event))
 
         let hasTimerTaskAfter = await sut.hasTimerTask
         XCTAssert(hasTimerTaskAfter)
@@ -127,7 +127,7 @@ final class EventQueueTests: XCTestCase {
             requestBuilder: requestBuilder,
             upload: { _ in })
 
-        await sut.enqueue(Mock.event)
+        await sut.enqueue(Mock.payload(event: Mock.event))
         await sut.flush()
 
         await waitForExpectations(timeout: 0.5)
@@ -156,7 +156,7 @@ final class EventQueueTests: XCTestCase {
             requestBuilder: requestBuilder,
             upload: upload)
 
-        await sut.enqueue(Mock.event)
+        await sut.enqueue(Mock.payload(event: Mock.event))
         await sut.flush()
 
         await waitForExpectations(timeout: 0.5)
@@ -182,9 +182,10 @@ final class EventQueueTests: XCTestCase {
             requestBuilder: requestBuilder,
             upload: { _ in })
 
-        await sut.enqueue(Mock.event(stream: stream1, name: name1))
-        await sut.enqueue(Mock.event(stream: stream2, name: name2))
-        await sut.enqueue(Mock.event(stream: stream1, name: name3))
+
+        await sut.enqueue(Mock.payload(stream: stream1, name: name1, event: Mock.event))
+        await sut.enqueue(Mock.payload(stream: stream2, name: name2, event: Mock.event))
+        await sut.enqueue(Mock.payload(stream: stream1, name: name3, event: Mock.event))
         await sut.flush()
 
         await waitForExpectations(timeout: 0.5)

--- a/Tests/LyticsTests/Helpers/Assert.swift
+++ b/Tests/LyticsTests/Helpers/Assert.swift
@@ -1,0 +1,136 @@
+//
+//  Assert.swift
+//
+//  Created by Mathew Gacy on 10/21/22.
+//
+
+@testable import Lytics
+import Foundation
+import XCTest
+
+/// Helper for testing equality of untyped dictionaries.
+enum Assert {
+
+    // MARK: - Untyped
+
+    static func attributeEquality(_ object: [String: Any], expected: [String: Any]) {
+        XCTAssertEqual(object["firstName"] as! String, expected["firstName"] as! String)
+        XCTAssertEqual(object["titles"] as! [String], expected["titles"] as! [String])
+    }
+
+    static func cartEquality(_ object: [String: Any], expected: [String: Any]) {
+        XCTAssertEqual(object["orderID"] as! String, expected["orderID"] as! String)
+        XCTAssertEqual(object["total"] as! Float, expected["total"] as! Float)
+    }
+
+    static func consentEquality(_ object: [String: Any], expected: [String: Any]) {
+        XCTAssertEqual(object["document"] as! String, expected["document"] as! String)
+        XCTAssertEqual(object["timestamp"] as! String, expected["timestamp"] as! String)
+        XCTAssertEqual(object["consented"] as! Bool, expected["consented"] as! Bool)
+    }
+
+    static func identifierEquality(_ object: [String: Any], expected: [String: Any]) {
+        XCTAssertEqual(object["email"] as! String, expected["email"] as! String)
+        XCTAssertEqual(object["userID"] as! Int, expected["userID"] as! Int)
+
+        // Nested
+        let nested = object["nested"] as! [String: Any]
+        let expectedNested = expected["nested"] as! [String: Any]
+        XCTAssertEqual(nested["a"] as! Int, expectedNested["a"] as! Int)
+        XCTAssertEqual(nested["b"] as! String, expectedNested["b"] as! String)
+    }
+
+    static func payloadMemberEquality(_ object: [String: Any], expected: [String: Any]) {
+        XCTAssertEqual(object["name"] as! String, expected["name"] as! String)
+        XCTAssertEqual(object["_ts"] as! Int64, expected["_ts"] as! Int64)
+        XCTAssertEqual(object["_sesstart"] as! Int?, expected["_sesstart"] as! Int?)
+    }
+
+    // MARK: - Untyped Events
+
+    static func consentEventEquality(_ object: [String: Any], expected: [String: Any]) {
+        Assert.payloadMemberEquality(object, expected: expected)
+
+        // Identifiers
+        let objectIdentifiers = object["identifiers"] as! [String: Any]
+        let expectedIdentifiers = expected["identifiers"] as! [String: Any]
+        Assert.identifierEquality(objectIdentifiers, expected: expectedIdentifiers)
+
+        // Attributes
+        let objectAttributes = object["attributes"] as! [String: Any]?
+        let expectedAttributes = expected["attributes"] as! [String: Any]?
+        if let objectAttributes, let expectedAttributes {
+            Assert.attributeEquality(objectAttributes, expected: expectedAttributes)
+        } else {
+            XCTAssert(objectAttributes == nil)
+            XCTAssert(expectedAttributes == nil)
+        }
+
+        // Consent
+        let objectConsent = object["consent"] as! [String: Any]
+        let expectedConsent = expected["consent"] as! [String: Any]
+        Assert.consentEquality(objectConsent, expected: expectedConsent)
+    }
+
+    static func eventEquality(_ object: [String: Any], expected: [String: Any]) {
+        Assert.payloadMemberEquality(object, expected: expected)
+
+        // Identifiers
+        let objectIdentifiers = object["identifiers"] as! [String: Any]
+        let expectedIdentifiers = expected["identifiers"] as! [String: Any]
+        Assert.identifierEquality(objectIdentifiers, expected: expectedIdentifiers)
+
+        // Properties
+        let objectProperties = object["properties"] as! [String: Any]
+        let expectedProperties = expected["properties"] as! [String: Any]
+        Assert.cartEquality(objectProperties, expected: expectedProperties)
+    }
+
+    static func identityEventEquality(_ object: [String: Any], expected: [String: Any]) {
+        Assert.payloadMemberEquality(object, expected: expected)
+
+        // Identifiers
+        let objectIdentifiers = object["identifiers"] as! [String: Any]
+        let expectedIdentifiers = expected["identifiers"] as! [String: Any]
+        Assert.identifierEquality(objectIdentifiers, expected: expectedIdentifiers)
+
+        // Attributes
+        let objectAttributes = object["attributes"] as! [String: Any]
+        let expectedAttributes = expected["attributes"] as! [String: Any]
+        Assert.attributeEquality(objectAttributes, expected: expectedAttributes)
+    }
+
+    // MARK: - Typed
+
+    static func equality(_ object: [String: Any], with attributes: TestAttributes) {
+        XCTAssertEqual(object["firstName"] as? String, attributes.firstName)
+        XCTAssertEqual(object["titles"] as? [String], attributes.titles)
+    }
+
+    static func equality(_ object: [String: Any], with cart: TestCart) {
+        XCTAssertEqual(object["orderId"] as! String, cart.orderId)
+        XCTAssertEqual(object["total"] as! Float, cart.total)
+    }
+
+    static func equality(_ object: [String: Any], with consent: TestConsent) {
+        XCTAssertEqual(object["document"] as! String, consent.document)
+        XCTAssertEqual(object["timestamp"] as! String, consent.timestamp)
+        XCTAssertEqual(object["consented"] as! Bool, consent.consented)
+    }
+
+    static func equality(_ object: [String: Any], with identifiers: TestIdentifiers) {
+        XCTAssertEqual(object["email"] as? String, identifiers.email)
+        XCTAssertEqual(object["userID"] as? Int, identifiers.userID)
+
+        // Nested
+        let nested = object["nested"] as! [String: Any]
+        XCTAssertEqual(nested["a"] as? Int, identifiers.nested?.a)
+        XCTAssertEqual(nested["b"] as? String, identifiers.nested?.b)
+    }
+
+    static func equality<E: Encodable>(_ object: [String: Any], payload: Payload<E>) {
+        XCTAssertEqual(object["name"] as? String, payload.name)
+        XCTAssertEqual(object["_ts"] as! Int64, payload.timestamp)
+        XCTAssertEqual(object["_sesstart"] as! Int?, payload.sessionDidStart)
+    }
+}

--- a/Tests/LyticsTests/Mocks/Mock.swift
+++ b/Tests/LyticsTests/Mocks/Mock.swift
@@ -9,22 +9,18 @@ import AnyCodable
 import Foundation
 
 enum Mock {
+    static let apiKey = "at.xxxx"
+
     static let consentEvent = ConsentEvent(
-        stream: "stream",
-        name: "name",
         identifiers: User1.identifiers,
         attributes: User1.attributes,
         consent: TestConsent.user1)
 
     static let event = Event(
-        stream: "stream",
-        name: "name",
         identifiers: User1.identifiers,
         properties: TestCart.user1)
 
     static let identityEvent = IdentityEvent(
-        stream: "stream",
-        name: "name",
         identifiers: TestIdentifiers.user1,
         attributes: TestAttributes.user1)
 
@@ -36,37 +32,113 @@ enum Mock {
 }
 
 extension Mock {
-    static func consentEvent(
-        stream: String,
-        name: String = "name"
-    ) -> ConsentEvent<TestConsent> {
-        .init(
-            stream: stream,
-            name: name,
-            identifiers: User1.identifiers,
-            attributes: User1.attributes,
-            consent: TestConsent.user1)
+    enum Name: String {
+        /// name_1.
+        case one = "name_1"
+        /// name_2.
+        case two = "name_2"
+        /// name_3.
+        case three = "name_3"
     }
 
-    static func event(
-        stream: String,
-        name: String = "name"
-    ) -> Event<TestCart> {
-        .init(
-            stream: stream,
-            name: name,
-            identifiers: User1.identifiers,
-            properties: TestCart.user1)
+    enum Stream: String {
+        /// stream_1.
+        case one = "stream_1"
+        /// stream_2.
+        case two = "stream_2"
+        /// stream_3.
+        case three = "stream_3"
     }
 
-    static func identityEvent(
-        stream: String,
-        name: String = "name"
-    ) -> IdentityEvent<TestIdentifiers, TestAttributes> {
+    enum Timestamp: Millisecond {
+        /// 1_666_000_000_000.
+        case one = 1_666_000_000_000
+        /// 1_666_000_001_000.
+        case two = 1_666_000_001_000
+        /// 1_666_000_002_500.
+        case three = 1_666_000_002_500
+    }
+
+    static func name(_ value: Name) -> String {
+        value.rawValue
+    }
+
+    static func stream(_ value: Stream) -> String {
+        value.rawValue
+    }
+
+    static func timestamp(_ value: Timestamp) -> Millisecond {
+        value.rawValue
+    }
+}
+
+extension Mock {
+    static func payload<E: Encodable>(
+        stream: String = Mock.stream(.one),
+        timestamp: Millisecond = Self.timestamp(.one),
+        sessionDidStart: Int? = nil,
+        name: String = Mock.name(.one),
+        event: E
+    ) -> Payload<E> {
         .init(
             stream: stream,
+            timestamp: timestamp,
+            sessionDidStart: sessionDidStart,
             name: name,
-            identifiers: TestIdentifiers.user1,
-            attributes: TestAttributes.user1)
+            event: event)
+    }
+
+    static func payloadDictionary(
+        stream: String = Mock.stream(.one),
+        timestamp: Millisecond = Self.timestamp(.one),
+        sessionDidStart: Int? = nil,
+        name: String? = Mock.name(.one)
+    ) -> [String: Any] {
+        var dict: [String: Any] = [
+            "stream": stream,
+            "_ts": timestamp,
+        ]
+
+        if let sessionDidStart {
+            dict["_sesstart"] = sessionDidStart
+        }
+
+        if let name {
+            dict["name"] = name
+        }
+
+        return dict
+    }
+
+    static func consentEventDictionary(
+        payload: inout [String: Any],
+        identifiers: [String: Any]? = nil,
+        attributes: [String: Any]? = nil,
+        consent: [String: Any]? = nil
+    ) -> [String: Any] {
+        payload["identifiers"] = identifiers
+        payload["attributes"] = attributes
+        payload["consent"] = consent
+        return payload
+    }
+
+    static func eventDictionary(
+        payload: inout [String: Any],
+        identifiers: [String: Any]? = nil,
+        properties: [String: Any]? = nil
+    ) -> [String: Any] {
+        payload["identifiers"] = identifiers
+        payload["properties"] = properties
+        return payload
+    }
+
+    static func identityEventDictionary(
+        payload: inout [String: Any],
+        identifiers: [String: Any]? = nil,
+        attributes: [String: Any]? = nil
+    ) -> [String: Any] {
+        payload["identifiers"] = identifiers
+        payload["attributes"] = attributes
+        return payload
     }
 }

--- a/Tests/LyticsTests/Models/Users.swift
+++ b/Tests/LyticsTests/Models/Users.swift
@@ -17,7 +17,7 @@ enum User1 {
     static let a = 1
     static let b = "2"
 
-    static let identifiers: [String: AnyCodable] = [
+    static let anyIdentifiers: [String: Any] = [
         "email": "someemail@lytics.com",
         "userID": 1234,
         "nested": [
@@ -26,8 +26,16 @@ enum User1 {
         ]
     ]
 
-    static let attributes: [String: AnyCodable] = [
+    static var identifiers: [String: AnyCodable] {
+        anyIdentifiers.mapValues(AnyCodable.init(_:))
+    }
+
+    static let anyAttributes: [String: Any] = [
         "firstName": "Jane",
         "titles": ["VP Product", "Reviewer"]
     ]
+
+    static var attributes: [String: AnyCodable] {
+        anyAttributes.mapValues(AnyCodable.init(_:))
+    }
 }

--- a/Tests/LyticsTests/RequestFailureHandlerTests.swift
+++ b/Tests/LyticsTests/RequestFailureHandlerTests.swift
@@ -1,0 +1,71 @@
+//
+//  RequestFailureHandler.swift
+//
+//  Created by Mathew Gacy on 10/21/22.
+//
+
+@testable import Lytics
+import Foundation
+import XCTest
+
+final class RequestFailureHandlerTests: XCTestCase {
+    let maxRetryCount: Int = 3
+    let initialDelay: TimeInterval = 10
+    let delayMultiplier: Double = 1.0
+
+    func testRetryStrategy() {
+        let sut = RequestFailureHandler(
+            configuration: .init(
+                maxRetryCount: maxRetryCount,
+                initialDelay: initialDelay,
+                delayMultiplier: delayMultiplier))
+
+        let error = NetworkError.invalidResponse(nil)
+
+        var retryCount: Int = 0
+
+        // Initial Retry
+        let initialRetry = sut.strategy(for: error, retryCount: retryCount)
+        XCTAssertEqual(initialRetry, .retry(initialDelay))
+        retryCount += 1
+
+        // Second Retry
+        let secondRetry = sut.strategy(for: error, retryCount: retryCount)
+        XCTAssertEqual(secondRetry, .retry(initialDelay * 2))
+        retryCount += 1
+
+        // Final retry
+        let finalRetry = sut.strategy(for: error, retryCount: retryCount)
+        XCTAssertEqual(finalRetry, .retry(initialDelay * 4))
+        retryCount += 1
+
+        // Store
+        let finalStrategy = sut.strategy(for: error, retryCount: retryCount)
+        XCTAssertEqual(finalStrategy, .store)
+    }
+
+    func testDiscardStrategy() {
+        let sut = RequestFailureHandler(
+            configuration: .init(
+                maxRetryCount: maxRetryCount,
+                initialDelay: initialDelay,
+                delayMultiplier: delayMultiplier))
+
+        var caughtError: Error!
+        do {
+            _ = try JSONDecoder().decode(
+                Bool.self,
+                from: Data("abc".utf8))
+        } catch {
+            caughtError = error
+        }
+
+        let strategy = sut.strategy(for: caughtError, retryCount: 0)
+        switch strategy {
+        case .discard:
+            return
+        case .retry, .store:
+            XCTFail("Unexpected strategy: \(strategy)")
+        }
+    }
+}

--- a/Tests/LyticsTests/UserManagerTests.swift
+++ b/Tests/LyticsTests/UserManagerTests.swift
@@ -10,12 +10,15 @@ import Foundation
 import XCTest
 
 final class UserManagerTests: XCTestCase {
+    let expectationTimeout: TimeInterval = 0.1
 
     func testUpdate() async throws {
         let a = 1
         let b = "2"
 
-        let sut = UserManager()
+        let sut = UserManager(
+            encoder: .init(),
+            storage: .mock)
 
         let firstResult = try await sut.update(
             with: UserUpdate(
@@ -86,5 +89,58 @@ final class UserManagerTests: XCTestCase {
                     "titles": User1.titles
                 ])
         )
+    }
+
+    func testUpdateIdentifiersStorage() async throws {
+        var storage = UserStorage.mock
+
+        var storedIdentifiers: [String: Any]!
+        let storeExpectation = expectation(description: "Identifiers were stored")
+        storage.storeIdentifiers = { identifiers in
+            storedIdentifiers = identifiers
+            storeExpectation.fulfill()
+        }
+
+        let sut = UserManager(encoder: .init(), storage: storage)
+
+        try await sut.updateIdentifiers(with: User1.identifiers)
+
+        await waitForExpectations(timeout: expectationTimeout)
+        Assert.identifierEquality(storedIdentifiers, expected: User1.anyIdentifiers)
+    }
+
+    func testUpdateAttributesStorage() async throws {
+        var storage = UserStorage.mock
+
+        var storedAttributes: [String: Any]!
+        let storeExpectation = expectation(description: "Attributes were stored")
+        storage.storeAttributes = { attributes in
+            storedAttributes = attributes
+            storeExpectation.fulfill()
+        }
+
+        let sut = UserManager(encoder: .init(), storage: storage)
+
+        try await sut.updateAttributes(with: User1.attributes)
+
+        await waitForExpectations(timeout: expectationTimeout)
+        Assert.attributeEquality(storedAttributes, expected: User1.anyAttributes)
+    }
+
+    func testLoadStoredOnInit() async throws {
+        let expectedAttributes = User1.anyAttributes
+        let expectedIdentifiers = User1.anyIdentifiers
+
+        var storage = UserStorage.mock
+        storage.attributes = { expectedAttributes }
+        storage.identifiers = { expectedIdentifiers }
+
+        let sut = UserManager(encoder: .init(), storage: storage)
+
+        let attributes = await sut.attributes
+        let identifiers = await sut.identifiers
+
+        Assert.attributeEquality(attributes, expected: expectedAttributes)
+        Assert.identifierEquality(identifiers, expected: expectedIdentifiers)
     }
 }

--- a/Tests/LyticsTests/UtilityTests.swift
+++ b/Tests/LyticsTests/UtilityTests.swift
@@ -8,7 +8,10 @@
 import Foundation
 import XCTest
 
-final class UtilityTests: XCTestCase {
+final class UtilityTests: XCTestCase {}
+
+// MARK: - Deep-Merging Dictionaries
+extension UtilityTests {
     func testSimpleDeepMerging() throws {
         let initial: [String: Any] = [
             "a": "initial",
@@ -52,5 +55,75 @@ final class UtilityTests: XCTestCase {
 
         XCTAssertEqual(cDictionary["d"] as? Int, 3)
         XCTAssertEqual(cDictionary["e"] as? Int, 5)
+    }
+}
+
+// MARK: - Appending JSON Array Data
+extension UtilityTests {
+    var emptyJSONData: Data {
+        Data("""
+        []
+        """.utf8)
+    }
+
+    var lhsJSONData: Data {
+        Data("""
+        [{"id":1},{"id":2}]
+        """.utf8)
+    }
+
+    var rhsJSONData: Data {
+        Data("""
+        [{"id":3},{"id":4}]
+        """.utf8)
+    }
+
+    var joinedJSONData: Data {
+        Data("""
+        [{"id":1},{"id":2},{"id":3},{"id":4}]
+        """.utf8)
+    }
+
+    var invalidJSONData: Data {
+        Data("abcd".utf8)
+    }
+
+    func testAppendJSONArrayData() throws {
+        var initialData = lhsJSONData
+        var additionalData = rhsJSONData
+
+        try initialData.append(jsonArray: &additionalData)
+
+        XCTAssertEqual(initialData, joinedJSONData)
+    }
+
+    func testAppendToEmptyJSONArrayData() throws {
+        var initialData = emptyJSONData
+        var additionalData = rhsJSONData
+
+        try initialData.append(jsonArray: &additionalData)
+
+        XCTAssertEqual(initialData, rhsJSONData)
+    }
+
+    func testAppendEmptyJSONArrayData() throws {
+        var initialData = lhsJSONData
+        var additionalData = emptyJSONData
+
+        try initialData.append(jsonArray: &additionalData)
+
+        XCTAssertEqual(initialData, lhsJSONData)
+    }
+
+    func testAppendToInvalidArrayThrows() throws {
+        var initialData = lhsJSONData
+        var additionalData = invalidJSONData
+        XCTAssertThrowsError(try initialData.append(jsonArray: &additionalData))
+    }
+
+    func testAppendInvalidArrayThrows() {
+        var initialData = invalidJSONData
+        var additionalData = rhsJSONData
+        XCTAssertThrowsError(try initialData.append(jsonArray: &additionalData))
     }
 }


### PR DESCRIPTION
This provides a `live` implementation of `DataUploadRequestBuilder`, stubs `Uploader`, and adds tests for `EventQueue` and `DataUploadRequestBuilder`.

`DataUploadRequestBuilder` is responsible for encoding events destined for different event streams and creating the corresponding requests. `JSONEncoder` cannot encode an array of existentials so we have to manage the data manually and iterate over each element, encode the opened `StreamEvent`, and add that to the encoded data. The rather tedious tests in `DataUploadRequestBuilderTests` are to ensure that this process is correct.