### PR TITLE
Use Actions to Convert and Upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,17 +16,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build and Test
+      - name: Build and test
         uses: mxcl/xcodebuild@v1
         with:
           xcode: ^14
           platform: iOS
           code-coverage: true
-      - name: Convert Code Coverage
+      - name: Convert coverage
         uses: sersoft-gmbh/swift-coverage-action@v3
         id: coverage-files
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{join(fromJSON(steps.coverage-files.outputs.files), ',')}}
+          files: ${{ join(fromJSON(steps.coverage-files.outputs.files), ',') }}


### PR DESCRIPTION
Uses GitHub actions to convert Xcode code coverage to a format accepted by Codecov and the Codecov action to upload it