### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout main
+      - name: Git checkout
         uses: actions/checkout@v3
 
-      - name: Bump Version File
+      - name: Bump Version file
         id: bump
         run: |
          echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --bump ${{ inputs.release_type }})"


### PR DESCRIPTION
This addresses #79 and adds a workflow to help automate releases. The expectation is that the final step before a new a release would be to create a PR for an update to the `Version.swift` file that is used to determine the SDK version number reported to the API.

This action would be invoked manually with a required input to specify release type (patch, minor, or major):

![sc_2023125_114520_788](https://user-images.githubusercontent.com/422815/214655094-cc2ed8aa-6ac9-47d2-a546-4c3327de2ca9.png)

The workflow will then:

- Increment the version number in `Version.swift` according to the release type selected when invoking the command 
- Commit the change
- Open a PR for the change

An example of the results of this workflow is visible [here](https://github.com/mgacy/package-release-workflow/pull/7).

An alternative implementation could instead commit the change directly to `main` and use the new version number to tag the commit. 