### PR TITLE
Add CurrentUserManager.idfaProvider

### DIFF
--- a/Sources/Lytics/AppTrackingTransparency.swift
+++ b/Sources/Lytics/AppTrackingTransparency.swift
@@ -30,7 +30,7 @@ extension AppTrackingTransparency {
                 userDefaults.set(true, for: .idfaIsEnabled)
             },
             idfa: {
-                guard ATTrackingManager.trackingAuthorizationStatus == .authorized else {
+                guard userDefaults.bool(for: .idfaIsEnabled), ATTrackingManager.trackingAuthorizationStatus == .authorized else {
                     return nil
                 }
 

--- a/Sources/Lytics/DependencyContainer.swift
+++ b/Sources/Lytics/DependencyContainer.swift
@@ -37,7 +37,12 @@ extension DependencyContainer {
             requestBuilder: requestBuilder
         )
 
-        let userManager = UserManager.live(configuration: configuration)
+        let appTrackingTransparency = AppTrackingTransparency.live
+
+        let userManager = UserManager.live(
+            configuration: configuration,
+            idfaProvider: appTrackingTransparency.idfa
+        )
 
         return .init(
             apiToken: apiToken,
@@ -48,7 +53,7 @@ extension DependencyContainer {
                 eventPipeline: eventPipeline,
                 onEvent: appEventHandler
             ),
-            appTrackingTransparency: .live,
+            appTrackingTransparency: appTrackingTransparency,
             configuration: configuration,
             eventPipeline: eventPipeline,
             loader: .live(

--- a/Sources/Lytics/UserManager.swift
+++ b/Sources/Lytics/UserManager.swift
@@ -21,7 +21,7 @@ actor UserManager: UserManaging {
     }
 
     private let configuration: Configuration
-    private var idfaProvider: () -> String?
+    private let idfaProvider: () -> String?
     private let idProvider: () -> String
     private let encoder: JSONEncoder
     private let storage: UserStorage

--- a/Tests/LyticsTests/UserManagerTests.swift
+++ b/Tests/LyticsTests/UserManagerTests.swift
@@ -28,6 +28,7 @@ final class UserManagerTests: XCTestCase {
 
         let sut = UserManager(
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -128,6 +129,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(anonymousIdentityKey: anonymousIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -168,6 +170,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(anonymousIdentityKey: anonymousIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -226,7 +229,11 @@ final class UserManagerTests: XCTestCase {
             }
         )
 
-        let sut = UserManager(encoder: .init(), storage: storage)
+        let sut = UserManager(
+            encoder: .init(),
+            idfaProvider: { nil },
+            storage: storage
+        )
 
         try await sut.updateIdentifiers(with: User1.identifiers)
 
@@ -244,7 +251,11 @@ final class UserManagerTests: XCTestCase {
             }
         )
 
-        let sut = UserManager(encoder: .init(), storage: storage)
+        let sut = UserManager(
+            encoder: .init(),
+            idfaProvider: { nil },
+            storage: storage
+        )
 
         try await sut.updateAttributes(with: User1.attributes)
 
@@ -260,7 +271,11 @@ final class UserManagerTests: XCTestCase {
             identifiers: { expectedIdentifiers }
         )
 
-        let sut = UserManager(encoder: .init(), storage: storage)
+        let sut = UserManager(
+            encoder: .init(),
+            idfaProvider: { nil },
+            storage: storage
+        )
 
         let attributes = await sut.attributes
         let identifiers = await sut.identifiers
@@ -281,6 +296,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(anonymousIdentityKey: anonymousIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -303,6 +319,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(anonymousIdentityKey: anonymousIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -327,6 +344,7 @@ final class UserManagerTests: XCTestCase {
         _ = UserManager(
             configuration: .init(anonymousIdentityKey: initialIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { initialIdentityValue },
             storage: storage
         )
@@ -334,6 +352,7 @@ final class UserManagerTests: XCTestCase {
         _ = UserManager(
             configuration: .init(anonymousIdentityKey: updatedIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { updatedIdentityValue },
             storage: storage
         )
@@ -366,6 +385,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -389,6 +409,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -420,6 +441,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(anonymousIdentityKey: anonymousIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             idProvider: { Mock.uuidString },
             storage: storage
         )
@@ -452,6 +474,7 @@ final class UserManagerTests: XCTestCase {
         let sut = UserManager(
             configuration: .init(anonymousIdentityKey: anonymousIdentityKey),
             encoder: .init(),
+            idfaProvider: { nil },
             storage: storage
         )
 

--- a/Tests/LyticsTests/UserManagerTests.swift
+++ b/Tests/LyticsTests/UserManagerTests.swift
@@ -367,6 +367,67 @@ final class UserManagerTests: XCTestCase {
         )
     }
 
+    func testIDFAIsAdded() async {
+        let expectedIDFA = "11111111-1111-1111-1111-111111111111"
+        let expectedIdentifiers: [String: String] = [
+            Constants.defaultAnonymousIdentityKey: Mock.uuidString,
+            Constants.idfaKey: expectedIDFA
+        ]
+
+        let idfaProvider: () -> String? = {
+            expectedIDFA
+        }
+
+        var storedIdentifiers: [String: Any]! = [Constants.defaultAnonymousIdentityKey: Mock.uuidString]
+        let storage = UserStorage.mock(
+            identifiers: { storedIdentifiers },
+            storeIdentifiers: { storedIdentifiers = $0 }
+        )
+
+        let sut = UserManager(
+            configuration: .init(),
+            encoder: .init(),
+            idfaProvider: idfaProvider,
+            idProvider: { Mock.uuidString },
+            storage: storage
+        )
+
+        let actualIdentifiers = await sut.identifiers
+        XCTAssertEqual(actualIdentifiers as! [String: String], expectedIdentifiers)
+    }
+
+    func testIDFAIsPreserved() async throws {
+        let expectedIDFA = "11111111-1111-1111-1111-111111111111"
+        let expectedIdentifiers: [String: String] = [
+            Constants.defaultAnonymousIdentityKey: Mock.uuidString,
+            Constants.idfaKey: expectedIDFA
+        ]
+
+        let idfaProvider: () -> String? = {
+            expectedIDFA
+        }
+
+        var storedIdentifiers: [String: Any]! = [Constants.defaultAnonymousIdentityKey: Mock.uuidString]
+        let storage = UserStorage.mock(
+            identifiers: { storedIdentifiers },
+            storeIdentifiers: { storedIdentifiers = $0 }
+        )
+
+        let sut = UserManager(
+            configuration: .init(),
+            encoder: .init(),
+            idfaProvider: idfaProvider,
+            idProvider: { Mock.uuidString },
+            storage: storage
+        )
+
+        let userUpdate: [String: AnyCodable] = [Constants.idfaKey: "mutated"]
+        try await sut.updateIdentifiers(with: userUpdate)
+
+        let actualIdentifiers = await sut.identifiers
+        XCTAssertEqual(actualIdentifiers as! [String: String], expectedIdentifiers)
+    }
+
     func testRemoveIdentifier() async {
         let expectedIdentifiers: [String: Any] = [
             "email": "someemail@lytics.com",


### PR DESCRIPTION
Removes `idfa` from stored values in favor of an `idfaProvider` member on `CurrentUserManager`. The `live` implementation always uses `ASIdentifierManager.advertisingIdentifier` in accordance with the guidance in the [documentation](https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614151-advertisingidentifier):

> As a best practice, don’t store the advertising identifier value; access advertisingIdentifier instead. Users can change their authorization for tracking at any time in Settings > Privacy > Tracking. Check your app’s authorization using the App Tracking Transparency API trackingAuthorizationStatus to determine the user’s intent.

This prevents users from setting custom `IDFA`s and ensures that the correct value is always used.

This addresses the primary concern of #53 