### PR TITLE
Action to Build Documentation

### DIFF
--- a/.github/actions/generate-docc/action.yml
+++ b/.github/actions/generate-docc/action.yml
@@ -1,0 +1,32 @@
+name: Generate DocC
+
+description: Generates documentation using the SwiftDocC Plugin.
+
+inputs:
+  hosting-base-path:
+    description: The base path where the documentation will be published; this is probably the repo name.
+    required: true
+  output-path:
+    description: The path for the documentation output.
+    required: true
+  target:
+    description: The name of the target.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Generate
+      shell: bash
+      run: |
+        export BUILDING_FOR_DOCUMENTATION_GENERATION=YES
+        export DOCC_JSON_PRETTYPRINT=YES
+
+        swift package \
+          --allow-writing-to-directory ${{ inputs.output-path }}/docs \
+          generate-documentation \
+          --target ${{ inputs.target }} \
+          --disable-indexing \
+          --transform-for-static-hosting \
+          --hosting-base-path ${{ inputs.hosting-base-path }} \
+          --output-path ${{ inputs.output-path }}/docs

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,6 @@
 name: Generate DocC
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
 
 env:
   GH-PAGES-BRANCH: 'gh-pages'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,51 @@
+name: Generate DocC
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+env:
+  GH-PAGES-BRANCH: 'gh-pages'
+  GH-PAGES-PATH: 'gh-pages'
+
+jobs:
+  build:
+    runs-on: macos-12
+    steps:
+      - name: Git checkout main
+        uses: actions/checkout@v3
+
+      - name: Git checkout gh-pages
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GH-PAGES-BRANCH }}
+          path: ${{ env.GH-PAGES-PATH }}
+
+      - name: Build DocC for Lytics
+        uses: ./.github/actions/generate-docc
+        with:
+          hosting-base-path: ios-sdk
+          output-path: ${{ env.GH-PAGES-PATH }}
+          target: Lytics
+
+      - name: Build DocC for LyticsUI
+        uses: ./.github/actions/generate-docc
+        with:
+          hosting-base-path: ios-sdk
+          output-path: ${{ env.GH-PAGES-PATH }}
+          target: LyticsUI
+
+      - name: Commit
+        id: commit
+        run: |
+            CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+            cd ${{ env.GH-PAGES-PATH }}
+            git add docs
+            if [ -n "$(git status --porcelain)" ]; then
+                echo "Documentation changes found. Commiting the changes to the pages branch and pushing to origin."
+                git commit -m "Update GitHub Pages documentation site to '$CURRENT_COMMIT_HASH'."
+                git push origin HEAD:${{ env.GH-PAGES-BRANCH }}
+            else
+              # No changes found, nothing to commit.
+              echo "No documentation changes found."
+            fi

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ enum CIWorkflow: String {
     /// The environment variable used to indicate that a particular workflow is active.
     static let environmentVariable = "LYTICS_SWIFT_CI"
 
+    case documentation = "BUILDING_FOR_DOCUMENTATION_GENERATION"
     case release = "BUILDING_FOR_RELEASE"
 
     init?(cString: UnsafeMutablePointer<CChar>?) {
@@ -71,6 +72,10 @@ workflow = nil
 
 // Only require additional dependencies when needed for CI
 switch workflow {
+case .documentation:
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+    ]
 case .release:
     package.dependencies += [
         .package(url: "https://github.com/mobelux/swift-version-file-plugin", from: "0.1.0")

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,10 @@
 
 import PackageDescription
 
+enum EnvironmentKey {
+    static let buildingDocs = "BUILDING_FOR_DOCUMENTATION_GENERATION"
+}
+
 let package = Package(
     name: "lytics",
     platforms: [
@@ -43,3 +47,19 @@ let package = Package(
             dependencies: ["Lytics"])
     ]
 )
+
+
+#if canImport(Darwin)
+import Darwin
+let buildingDocs = getenv(EnvironmentKey.buildingDocs) != nil
+#elseif canImport(Glibc)
+import Glibc
+let buildingDocs = getenv(EnvironmentKey.buildingDocs) != nil
+#else
+let buildingDocs = false
+#endif
+
+// Only require the docc plugin when building documentation
+package.dependencies += buildingDocs ? [
+  .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+] : []


### PR DESCRIPTION
Adds a workflow to compile documentation with the [Swift-DocC](https://github.com/apple/swift-docc-plugin) and commit changes to the `gh-pages` branch for use with [GitHub Pages](https://pages.github.com/).

The package manifest uses an environment variable to conditionally declare package plugin dependency.