### PR TITLE
Make Plugin Dependency Conditional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Bump Version file
         id: bump
         run: |
-         echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --bump ${{ inputs.release_type }})"
+         echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --target Lytics --bump ${{ inputs.release_type }})"
 
       - name: Create pull request
         id: cpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ on:
           - minor
           - major
 
-env:
-  VERSION-FILE-PATH: 'Sources/Lytics/Version.swift'
-
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
           export LYTICS_SWIFT_CI=BUILDING_FOR_RELEASE
           echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --target Lytics --bump ${{ inputs.release_type }})"
 
+      - name: Restore Package.resolved
+        run: |
+          git restore Package.resolved
+
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Bump Version file
         id: bump
         run: |
-         echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --target Lytics --bump ${{ inputs.release_type }})"
+          export LYTICS_SWIFT_CI=BUILDING_FOR_RELEASE
+          echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --target Lytics --bump ${{ inputs.release_type }})"
 
       - name: Create pull request
         id: cpr

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "swift-version-file-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mobelux/swift-version-file-plugin",
-      "state" : {
-        "revision" : "b5bb65e2166ecf927ad20643e86501d5607f9cfc",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,9 @@ let package = Package(
 
 // MARK: - Additional Dependencies for CI
 
-enum CI: String {
+/// A representation of CI workflows that require additional Swift Package Manager plugins.
+enum CIWorkflow: String {
+    /// The environment variable used to indicate that a particular workflow is active.
     static let environmentVariable = "LYTICS_SWIFT_CI"
 
     case release = "BUILDING_FOR_RELEASE"
@@ -56,13 +58,13 @@ enum CI: String {
     }
 }
 
-let workflow: CI?
+let workflow: CIWorkflow?
 #if canImport(Darwin)
 import Darwin
-workflow = CI(cString: getenv(CI.environmentVariable))
+workflow = CIWorkflow(cString: getenv(CIWorkflow.environmentVariable))
 #elseif canImport(Glibc)
 import Glibc
-workflow = CI(cString: getenv(CI.environmentVariable))
+workflow = CIWorkflow(cString: getenv(CIWorkflow.environmentVariable))
 #else
 workflow = nil
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,6 @@ let package = Package(
             url: "https://github.com/Flight-School/AnyCodable",
             from: "0.6.7"),
         .package(
-            url: "https://github.com/mobelux/swift-version-file-plugin",
-            from: "0.1.0"),
-        .package(
             url: "https://github.com/nicklockwood/SwiftFormat",
             from: "0.50.6")
     ],
@@ -43,3 +40,39 @@ let package = Package(
             dependencies: ["Lytics"])
     ]
 )
+
+// MARK: - Additional Dependencies for CI
+
+enum CI: String {
+    static let environmentVariable = "LYTICS_SWIFT_CI"
+
+    case release = "BUILDING_FOR_RELEASE"
+
+    init?(cString: UnsafeMutablePointer<CChar>?) {
+        guard let cString else {
+            return nil
+        }
+        self.init(rawValue: String(cString: cString))
+    }
+}
+
+let workflow: CI?
+#if canImport(Darwin)
+import Darwin
+workflow = CI(cString: getenv(CI.environmentVariable))
+#elseif canImport(Glibc)
+import Glibc
+workflow = CI(cString: getenv(CI.environmentVariable))
+#else
+workflow = nil
+#endif
+
+// Only require additional dependencies when needed for CI
+switch workflow {
+case .release:
+    package.dependencies += [
+        .package(url: "https://github.com/mobelux/swift-version-file-plugin", from: "0.1.0")
+    ]
+case .none:
+    break
+}


### PR DESCRIPTION
Uses an environment variable to conditionally declare a VersionFilePlugin dependency.

The release workflow sets an environment variable before invoking the package plugin. The package manifest checks if there is a value for `LYTICS_SWIFT_CI` and if it is `BUILDING_FOR_RELEASE`, adds an additional package dependency. The expectation is that this can be expanded to support a conditional dependency on the Swift-DocC Plugin plugin as part of a documentation workflow, for example.

The `Release` workflow was also updated to reset changes to `Package.resolved` before creating a PR.

Finally, this fixes an issue where the VersionFilePlugin fails due to a failure to specify the target (now that there are two)