### PR TITLE
Fix Swift 5.8 Build Warnings

### DIFF
--- a/Tests/LyticsTests/AppEventTrackerTests.swift
+++ b/Tests/LyticsTests/AppEventTrackerTests.swift
@@ -34,19 +34,19 @@ final class AppEventTrackerTests: XCTestCase {
         // didBecomeActive
         handlerExpectation = expectation(description: "didBecomeActive handled")
         await center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [handlerExpectation], timeout: 1.0)
         XCTAssertEqual(handledEvent, .didBecomeActive)
 
         // didEnterBackground
         handlerExpectation = expectation(description: "didEnterBackground handled")
         await center.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [handlerExpectation], timeout: 1.0)
         XCTAssertEqual(handledEvent, .didEnterBackground)
 
         // willTerminate
         handlerExpectation = expectation(description: "willTerminate handled")
         await center.post(name: UIApplication.willTerminateNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [handlerExpectation], timeout: 1.0)
         XCTAssertEqual(handledEvent, .willTerminate)
     }
 

--- a/Tests/LyticsTests/AppEventTrackerTests.swift
+++ b/Tests/LyticsTests/AppEventTrackerTests.swift
@@ -72,7 +72,7 @@ final class AppEventTrackerTests: XCTestCase {
 
         handlerExpectation = expectation(description: "Event handled")
         await center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [handlerExpectation], timeout: 1.0)
 
         sut = nil
 
@@ -80,7 +80,7 @@ final class AppEventTrackerTests: XCTestCase {
         handlerExpectation = expectation(description: "Event not handled")
         handlerExpectation.isInverted = true
         await center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [handlerExpectation], timeout: 1.0)
     }
 
     func testAppLifecycleEventsSent() async throws {
@@ -113,14 +113,14 @@ final class AppEventTrackerTests: XCTestCase {
         // didBecomeActive
         eventExpectation = expectation(description: "didBecomeActive sent")
         await center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation], timeout: 1.0)
         XCTAssertEqual(eventName, EventNames.appOpen)
         XCTAssertEqual(streamName, expectedStream)
 
         // didEnterBackground
         eventExpectation = expectation(description: "didEnterBackground sent")
         await center.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation], timeout: 1.0)
         XCTAssertEqual(eventName, EventNames.appBackground)
         XCTAssertEqual(streamName, expectedStream)
     }
@@ -151,7 +151,7 @@ final class AppEventTrackerTests: XCTestCase {
         await center.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
         await center.post(name: UIApplication.willTerminateNotification, object: nil)
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation], timeout: 1.0)
     }
 
     func testAppVersionEventsSent() async throws {
@@ -179,7 +179,7 @@ final class AppEventTrackerTests: XCTestCase {
             lifecycleEvents: center.lifecycleEvents(),
             versionTracker: .mock(.install("1.0"))
         )
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation], timeout: 1.0)
         XCTAssertEqual(eventName, EventNames.appInstall)
         sut.stopTracking()
 
@@ -189,7 +189,7 @@ final class AppEventTrackerTests: XCTestCase {
             lifecycleEvents: center.lifecycleEvents(),
             versionTracker: .mock(.update("1.1"))
         )
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation], timeout: 1.0)
         XCTAssertEqual(eventName, EventNames.appUpdate)
         sut.stopTracking()
     }
@@ -223,7 +223,7 @@ final class AppEventTrackerTests: XCTestCase {
         eventExpectation = expectation(description: "didBecomeActive sent")
         handlerExpectation = expectation(description: "Event handled")
         await center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation, handlerExpectation], timeout: 1.0)
 
         eventExpectation = expectation(description: "Event not sent")
         eventExpectation.isInverted = true
@@ -232,6 +232,6 @@ final class AppEventTrackerTests: XCTestCase {
 
         sut.stopTracking()
         await center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [eventExpectation, handlerExpectation], timeout: 1.0)
     }
 }

--- a/Tests/LyticsTests/DictionaryPathTests.swift
+++ b/Tests/LyticsTests/DictionaryPathTests.swift
@@ -18,7 +18,7 @@ final class DictionaryPathTests: XCTestCase {
                     "lon": "139.6917"
                 ],
                 "language": "japanese"
-            ]
+            ] as [String: Any]
         ],
         "airports": [
             "germany": ["FRA", "MUC", "HAM", "TXL"]

--- a/Tests/LyticsTests/EventPipelineTests.swift
+++ b/Tests/LyticsTests/EventPipelineTests.swift
@@ -229,6 +229,6 @@ final class EventPipelineTests: XCTestCase {
         )
 
         await sut.dispatch()
-        await waitForExpectations(timeout: 0.3)
+        await fulfillment(of: [flushExpectation], timeout: 0.3)
     }
 }

--- a/Tests/LyticsTests/EventQueueTests.swift
+++ b/Tests/LyticsTests/EventQueueTests.swift
@@ -41,7 +41,7 @@ final class EventQueueTests: XCTestCase {
         buildExpectation.isInverted = false
         await sut.enqueue(Mock.payload(event: Mock.identityEvent))
 
-        await waitForExpectations(timeout: Timeout.medium)
+        await fulfillment(of: [buildExpectation], timeout: Timeout.medium)
     }
 
     func testFlushAfterUploadInterval() async throws {
@@ -65,7 +65,7 @@ final class EventQueueTests: XCTestCase {
         await sut.enqueue(Mock.payload(event: Mock.consentEvent))
         await sut.enqueue(Mock.payload(event: Mock.event))
         await sut.enqueue(Mock.payload(event: Mock.identityEvent))
-        await waitForExpectations(timeout: Timeout.long)
+        await fulfillment(of: [buildExpectation], timeout: Timeout.long)
     }
 
     func testManualFlush() async throws {
@@ -95,7 +95,7 @@ final class EventQueueTests: XCTestCase {
         await sut.enqueue(Mock.payload(event: Mock.consentEvent))
         await sut.flush()
 
-        await waitForExpectations(timeout: Timeout.medium)
+        await fulfillment(of: [buildExpectation, uploadExpectation], timeout: Timeout.medium)
         XCTAssertEqual(uploadedRequests, [Mock.request])
 
         let isEmpty = await sut.isEmpty
@@ -149,7 +149,7 @@ final class EventQueueTests: XCTestCase {
         await sut.enqueue(Mock.payload(event: Mock.event))
         await sut.flush()
 
-        await waitForExpectations(timeout: Timeout.short)
+        await fulfillment(of: [logExpectation], timeout: Timeout.short)
     }
 
     func testEventsUploaded() async throws {
@@ -179,7 +179,7 @@ final class EventQueueTests: XCTestCase {
         await sut.enqueue(Mock.payload(event: Mock.event))
         await sut.flush()
 
-        await waitForExpectations(timeout: Timeout.short)
+        await fulfillment(of: [uploadExpectation], timeout: Timeout.short)
 
         XCTAssertEqual(uploadedRequests, requests)
     }
@@ -208,7 +208,7 @@ final class EventQueueTests: XCTestCase {
         await sut.enqueue(Mock.payload(stream: Stream.one, name: Name.three, event: Mock.event))
         await sut.flush()
 
-        await waitForExpectations(timeout: Timeout.short)
+        await fulfillment(of: [buildExpectation], timeout: Timeout.short)
 
         let stream1Events = events[Stream.one]!
         XCTAssertEqual(stream1Events.count, 2)

--- a/Tests/LyticsTests/Extensions/XCTestCase+Utils.swift
+++ b/Tests/LyticsTests/Extensions/XCTestCase+Utils.swift
@@ -1,0 +1,32 @@
+//
+//  XCTestCase+Utils.swift
+//
+//  Created by Mathew Gacy on 4/5/23.
+//
+
+import XCTest
+
+#if swift(<5.8)
+extension XCTestCase {
+    /// Waits on a group of expectations for up to the specified timeout, optionally enforcing their order of fulfillment.
+    ///
+    /// This allows use of Xcode 14.3's `XCTestCase.fulfillment(of:timeout:enforceOrder:)` method while maintaining
+    /// compatibility with previous versions.
+    ///
+    /// - Parameters:
+    ///   - expectations: An array of expectations the test must satisfy.
+    ///   - seconds: The time, in seconds, the test allows for the fulfillment of the expectations. The default timeout
+    ///   allows the test to run until it reaches its execution time allowance.
+    ///   - enforceOrderOfFulfillment: If `true`, the test must satisfy the expectations in the order they appear in
+    ///   the array.
+    func fulfillment(
+        of expectations: [XCTestExpectation],
+        timeout seconds: TimeInterval = .infinity,
+        enforceOrder enforceOrderOfFulfillment: Bool = false
+    ) async {
+        await MainActor.run {
+            wait(for: expectations, timeout: seconds, enforceOrder: enforceOrderOfFulfillment)
+        }
+    }
+}
+#endif

--- a/Tests/LyticsTests/LoaderTests.swift
+++ b/Tests/LyticsTests/LoaderTests.swift
@@ -57,7 +57,7 @@ final class LoaderTests: XCTestCase {
 
         let actualEntity = try await sut.entity(table, identifier)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [requestExpectation], timeout: 0.1)
 
         XCTAssertEqual(actualEntity, expectedEntity)
         XCTAssertEqual(
@@ -100,7 +100,7 @@ final class LoaderTests: XCTestCase {
             errorExpectation.fulfill()
         }
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [errorExpectation], timeout: 0.1)
         let requestCount = await counter.count
         XCTAssertEqual(requestCount, maxRetryCount + 1)
     }

--- a/Tests/LyticsTests/LyticsTests.swift
+++ b/Tests/LyticsTests/LyticsTests.swift
@@ -84,7 +84,7 @@ extension LyticsTests {
 
         let actualEnabled = sut.isIDFAEnabled
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [idfaExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualEnabled, expectedEnabled)
     }
@@ -107,7 +107,7 @@ extension LyticsTests {
 
         let actualEnabled = sut.isIDFAEnabled
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [idfaExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualEnabled, expectedEnabled)
     }
@@ -143,7 +143,7 @@ extension LyticsTests {
         let sut = Lytics(assertionFailure: { _, _, _ in failureExpectation.fulfill() }, logger: .mock)
 
         await _ = sut.user
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [failureExpectation], timeout: expectationTimeout)
     }
 
     func testHasStartedAfterStarting() {
@@ -200,7 +200,7 @@ extension LyticsTests {
             properties: TestCart.user1
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation, updateExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -248,7 +248,7 @@ extension LyticsTests {
             properties: TestCart.user1
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -294,7 +294,7 @@ extension LyticsTests {
             timestamp: expectedTimestamp
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -353,7 +353,7 @@ extension LyticsTests {
             shouldSend: true
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation, updateExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualTimestamp, expectedTimestamp)
@@ -409,7 +409,7 @@ extension LyticsTests {
             shouldSend: true
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation, updateExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualTimestamp, expectedTimestamp)
@@ -471,7 +471,7 @@ extension LyticsTests {
             shouldSend: true
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation, updateExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -529,7 +529,7 @@ extension LyticsTests {
             shouldSend: true
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation, updateExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -579,7 +579,7 @@ extension LyticsTests {
             shouldSend: true
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -636,7 +636,7 @@ extension LyticsTests {
             properties: TestCart.user1
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation, updateExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -685,7 +685,7 @@ extension LyticsTests {
             properties: TestCart.user1
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, expectedName)
@@ -719,7 +719,7 @@ extension LyticsTests {
 
         sut.updateUser(with: UserUpdate(identifiers: TestIdentifiers.user1, attributes: TestAttributes.user1))
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [loggerExpectation], timeout: expectationTimeout)
         XCTAssertEqual(actualLogLevel, expectedLogLevel)
     }
 
@@ -776,7 +776,7 @@ extension LyticsTests {
             Event<TestCart>(identifiers: eventIdentifiers, properties: .user1)
         }
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [loggerExpectation, eventExpectation], timeout: expectationTimeout)
         XCTAssertEqual(actualLogLevel, expectedLogLevel)
         XCTAssertEqual(actualEvent, expectedEvent)
     }
@@ -830,7 +830,7 @@ extension LyticsTests {
             Event<TestCart>(identifiers: user.identifiers, properties: .user1)
         }
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [loggerExpectation], timeout: expectationTimeout)
         XCTAssertEqual(actualLogLevel, expectedLogLevel)
     }
 
@@ -897,7 +897,7 @@ extension LyticsTests {
 
         let actualUser = try await sut.getProfile()
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [loaderExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualUser, expectedUser)
         XCTAssertEqual(actualTable, expectedTable)
@@ -950,7 +950,7 @@ extension LyticsTests {
             )
         )
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [loaderExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualUser, expectedUser)
         XCTAssertEqual(actualTable, expectedTable)
@@ -978,7 +978,7 @@ extension LyticsTests {
             errorExpectation.fulfill()
         }
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [errorExpectation], timeout: expectationTimeout)
     }
 
     func testGetProfileBeforeStarting() async {
@@ -993,7 +993,7 @@ extension LyticsTests {
             errorExpectation.fulfill()
         }
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [failureExpectation, errorExpectation], timeout: expectationTimeout)
     }
 }
 
@@ -1058,7 +1058,7 @@ extension LyticsTests {
 
         sut.continueUserActivity(userActivity, stream: expectedStream)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, "Deep Link")
@@ -1107,7 +1107,7 @@ extension LyticsTests {
 
         sut.openURL(expectedURL, options: options, stream: expectedStream)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, "URL")
@@ -1164,7 +1164,7 @@ extension LyticsTests {
 
         sut.shortcutItem(shortcutItem, stream: expectedStream)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [eventExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(actualStream, expectedStream)
         XCTAssertEqual(actualName, "Shortcut")
@@ -1185,7 +1185,7 @@ extension LyticsTests {
         )
 
         sut.optIn()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [optInExpectation], timeout: expectationTimeout)
     }
 
     func testOptInBeforeStarting() {
@@ -1206,7 +1206,7 @@ extension LyticsTests {
         )
 
         sut.optOut()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [optOutExpectation], timeout: expectationTimeout)
     }
 
     func testOptOutBeforeStarting() {
@@ -1253,7 +1253,7 @@ extension LyticsTests {
 
         let actualAuthorized = await sut.requestTrackingAuthorization()
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [idfaExpectation, requestExpectation, updateExpectation], timeout: expectationTimeout)
         XCTAssertEqual(actualAuthorized, expectedAuthorized)
         XCTAssertEqual(actualIdentifierDictionary, ["idfa": AnyCodable(expectedIDFA)])
     }
@@ -1263,7 +1263,7 @@ extension LyticsTests {
         let sut = Lytics(assertionFailure: { _, _, _ in failureExpectation.fulfill() }, logger: .mock)
 
         _ = await sut.requestTrackingAuthorization()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [failureExpectation], timeout: expectationTimeout)
     }
 
     func testDisableTracking() async {
@@ -1278,7 +1278,7 @@ extension LyticsTests {
         )
 
         sut.disableTracking()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [disableExpectation], timeout: expectationTimeout)
     }
 
     func testDisableTrackingBeforeStarting() {
@@ -1306,7 +1306,7 @@ extension LyticsTests {
         )
 
         sut.dispatch()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [dispatchExpectation], timeout: expectationTimeout)
     }
 
     func testDispatchBeforeStarting() {
@@ -1338,7 +1338,7 @@ extension LyticsTests {
 
         sut.removeIdentifier(expectedPath)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [removalExpectation], timeout: expectationTimeout)
         XCTAssertEqual(actualPath, expectedPath)
     }
 
@@ -1363,7 +1363,7 @@ extension LyticsTests {
 
         sut.removeAttribute(expectedPath)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [removalExpectation], timeout: expectationTimeout)
         XCTAssertEqual(actualPath, expectedPath)
     }
 
@@ -1393,7 +1393,7 @@ extension LyticsTests {
         )
 
         sut.reset()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [disableTrackingExpectation, optOutExpectation, clearUserExpectation], timeout: expectationTimeout)
     }
 
     func testResetBeforeStarting() {

--- a/Tests/LyticsTests/Models/Users.swift
+++ b/Tests/LyticsTests/Models/Users.swift
@@ -23,7 +23,7 @@ enum User1 {
         "nested": [
             "a": a,
             "b": b
-        ]
+        ] as [String: Any]
     ]
 
     static var identifiers: [String: AnyCodable] {

--- a/Tests/LyticsTests/TaskUtilityTests.swift
+++ b/Tests/LyticsTests/TaskUtilityTests.swift
@@ -27,7 +27,7 @@ final class TaskUtilityTests: XCTestCase {
             operation: operation
         ).value
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [completionExpectation], timeout: 0.1)
         XCTAssertEqual(result, expectedResult)
 
         let operationCount = await counter.count
@@ -65,7 +65,7 @@ final class TaskUtilityTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [handlerExpectation, errorExpectation], timeout: 0.1)
 
         XCTAssertEqual(caughtError, TestError(message: errorMessage))
         let operationCount = await counter.count

--- a/Tests/LyticsTests/UploaderTests.swift
+++ b/Tests/LyticsTests/UploaderTests.swift
@@ -42,7 +42,7 @@ final class UploaderTests: XCTestCase {
         let requestCount = await sut.pendingRequestCount
         XCTAssertEqual(requestCount, requests.count)
 
-        await fulfillment(of: [requestExpectation, ], timeout: 0.5)
+        await fulfillment(of: [requestExpectation], timeout: 0.5)
         XCTAssertEqual(performedRequest, requests.first!)
 
         // Delay to give uploader time to remove request

--- a/Tests/LyticsTests/UploaderTests.swift
+++ b/Tests/LyticsTests/UploaderTests.swift
@@ -42,7 +42,7 @@ final class UploaderTests: XCTestCase {
         let requestCount = await sut.pendingRequestCount
         XCTAssertEqual(requestCount, requests.count)
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [requestExpectation, ], timeout: 0.5)
         XCTAssertEqual(performedRequest, requests.first!)
 
         // Delay to give uploader time to remove request
@@ -73,7 +73,7 @@ final class UploaderTests: XCTestCase {
 
         let request = Mock.request
         await sut.upload([request])
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [cacheExpectation], timeout: 0.5)
 
         let cachedRequest = cachedRequests.first! as! PendingRequest<DataUploadResponse>
         XCTAssertEqual(cachedRequest.request, request)
@@ -98,7 +98,7 @@ final class UploaderTests: XCTestCase {
         // Upload attempt
         let request = Mock.request
         await sut.upload([request])
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [], timeout: 0.1)
 
         let cacheExpectation = expectation(description: "Request cached")
         var cachedRequests: [any RequestWrapping]!
@@ -108,7 +108,7 @@ final class UploaderTests: XCTestCase {
         }
 
         await sut.storeRequests()
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [requestExpectation, cacheExpectation], timeout: 0.1)
 
         let cachedRequest = cachedRequests.first! as! PendingRequest<DataUploadResponse>
         XCTAssertEqual(cachedRequest.request, request)
@@ -160,7 +160,7 @@ final class UploaderTests: XCTestCase {
 
         try await sut.loadRequests()
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [requestExpectation, loadExpectation, clearExpectation], timeout: 0.5)
         XCTAssertEqual(performedRequest, Mock.request)
     }
 
@@ -198,7 +198,7 @@ final class UploaderTests: XCTestCase {
         await sut.upload([request])
 
         // Wait for initial attempt
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [requestExpectation, failureStrategyExpectation], timeout: 0.1)
 
         // Retried request - store on failure
         requestExpectation = expectation(description: "Request was retried")
@@ -213,7 +213,7 @@ final class UploaderTests: XCTestCase {
         }
 
         // Wait for retried attempt and storage
-        await waitForExpectations(timeout: retryDelay * 2)
+        await fulfillment(of: [requestExpectation, failureStrategyExpectation, cacheExpectation], timeout: retryDelay * 2)
         let cachedRequest = cachedRequests.first! as! PendingRequest<DataUploadResponse>
         XCTAssertEqual(cachedRequest.request, request)
 
@@ -226,7 +226,7 @@ final class UploaderTests: XCTestCase {
         cacheExpectation.isInverted = true
 
         await sut.upload([Mock.request])
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [requestExpectation, failureStrategyExpectation, cacheExpectation], timeout: 0.5)
     }
 
     func testRequestsLoadedAfterSuccess() async throws {
@@ -256,6 +256,6 @@ final class UploaderTests: XCTestCase {
         )
 
         await sut.upload([Mock.request])
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(of: [requestExpectation, loadExpectation], timeout: 0.1)
     }
 }

--- a/Tests/LyticsTests/UserManagerTests.swift
+++ b/Tests/LyticsTests/UserManagerTests.swift
@@ -147,7 +147,7 @@ final class UserManagerTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [errorExpectation], timeout: expectationTimeout)
         XCTAssertEqual(caughtError!.userDescription, "Unable to create a dictionary from 1.")
     }
 
@@ -230,7 +230,7 @@ final class UserManagerTests: XCTestCase {
 
         try await sut.updateIdentifiers(with: User1.identifiers)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [storeExpectation], timeout: expectationTimeout)
         Assert.identifierEquality(storedIdentifiers, expected: User1.anyIdentifiers)
     }
 
@@ -248,7 +248,7 @@ final class UserManagerTests: XCTestCase {
 
         try await sut.updateAttributes(with: User1.attributes)
 
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [storeExpectation], timeout: expectationTimeout)
         Assert.attributeEquality(storedAttributes, expected: User1.anyAttributes)
     }
 
@@ -425,7 +425,7 @@ final class UserManagerTests: XCTestCase {
         )
 
         await sut.clear()
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [attributeExpectation, identifierExpectation], timeout: expectationTimeout)
 
         XCTAssertNil(storedAttributes)
         XCTAssertEqual(storedIdentifiers.count, 1)
@@ -456,7 +456,7 @@ final class UserManagerTests: XCTestCase {
         )
 
         let actualUser = await sut.user
-        await waitForExpectations(timeout: expectationTimeout)
+        await fulfillment(of: [attributeExpectation], timeout: expectationTimeout)
 
         XCTAssertEqual(
             actualUser,

--- a/Tests/LyticsTests/UserManagerTests.swift
+++ b/Tests/LyticsTests/UserManagerTests.swift
@@ -79,7 +79,7 @@ final class UserManagerTests: XCTestCase {
                     "nested": [
                         "a": a,
                         "b": b
-                    ]
+                    ] as [String: Any]
                 ],
                 attributes: [
                     "firstName": User1.firstName
@@ -103,7 +103,7 @@ final class UserManagerTests: XCTestCase {
                     "nested": [
                         "a": a,
                         "b": b
-                    ]
+                    ] as [String: Any]
                 ],
                 attributes: [
                     "firstName": User1.firstName,
@@ -192,7 +192,7 @@ final class UserManagerTests: XCTestCase {
                 "nested": [
                     "a": a,
                     "b": b
-                ]
+                ] as [String: Any]
             ]
         )
 


### PR DESCRIPTION
Swift 5.8 in Xcode 14.3 brought some new build warnings; this fixes them.

- adds explicit type annotations (`... as [String: Any]`) for nested, heterogeneous dictionaries
- updates tests to use the `XCTestCase.fulfillment(of:timeout:enforceOrder:)`that was added in Xcode 14.3 and, when compiled with Swift versions before 5.8, adds an extension to `XCTestCase` with the same signature. This was required by the addition of `@_unavailableFromAsync` to the expectation method that I had been using before. [Apparently](https://twitter.com/grynspan/status/1626432897832960000), those older methods can cause deadlocks