### PR TITLE
Remove Unsupported Configuration Members

### DIFF
--- a/Sources/Lytics/LyticsConfiguration.swift
+++ b/Sources/Lytics/LyticsConfiguration.swift
@@ -31,15 +31,6 @@ public struct LyticsConfiguration: Equatable {
     /// A Boolean value indicating whether application lifecycle events should be tracked automatically.
     public var trackApplicationLifecycleEvents: Bool = false
 
-    /// A Boolean value indicating whether screen views should be tracked automatically.
-    public var trackScreenViews: Bool = false
-
-    /// A Boolean value indicating whether push notifications should be tracked.
-    public var trackPushNotifications: Bool = false
-
-    /// A Boolean value indicating whether deep links should be tracked.
-    public var trackDeepLinks: Bool = false
-
     /// The interval in seconds at which the event queue is uploaded to the Lytics API.
     public var uploadInterval: Double = 10
 


### PR DESCRIPTION
Following the decision to drop automatic event collection in #56, support was not added for the capabilities referenced by the `LyticsConfiguration.trackScreenViews`, `.trackPushNotifications` or `.trackDeepLinks` members, but they were never removed. This fixes that by removing those members.

As a reminder, the SDK does offer the following members to make it easier to collect these and related events:

Using `AppDelegate`:

- `Lytics.continueUserActivity(_:stream:)`
- `Lytics.openURL(_:options:stream:)`
- `Lytics.shortcutItem(_:stream:)`

Using SwiftUI:

- `View.trackContinueUserActivity(_:with:stream:perform:)`
- `View.trackOpenURL(with:stream:perform:)`

Closes #117 