### PR TITLE
Fix GH Action Warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         id: bump
         run: |
           export LYTICS_SWIFT_CI=BUILDING_FOR_RELEASE
-          echo "::set-output name=version::$(swift package --allow-writing-to-package-directory version-file --target Lytics --bump ${{ inputs.release_type }})"
+          echo "version=$(swift package --allow-writing-to-package-directory version-file --target Lytics --bump ${{ inputs.release_type }})" >> $GITHUB_OUTPUT
 
       - name: Restore Package.resolved
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and test
         uses: mxcl/xcodebuild@v1
         with:


### PR DESCRIPTION
Fixes a couple GH Actions warnings:

- test: upgrade checkout action to v3
- release: replace [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `set-output` with use of [output parameter](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)