### PR TITLE
Add Swift Package Index Manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Lytics, LyticsUI]
+      platform: ios


### PR DESCRIPTION
Adds an [SPIManifest](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/0.17.2/documentation/spimanifest) file to configure hosting of documentation generated by the DocC compiler.

[DocC](https://developer.apple.com/documentation/docc) is Apple's recommended way to provide documentation for packages and they recently started sponsoring the Swift Package Index. Once this package is tagged and added to the SPI, the docs will be visible from the package's page on SPI.

NOTE: it is also possible to [specify existing documentation](https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.17.2/documentation/spimanifest/commonusecases#Configure-a-documentation-URL-for-existing-documentation)  