### PR TITLE
Workflow to Tag Releases

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,41 @@
+name: Tag Release
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'main'
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.head_ref == 'release'
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+
+      - name: Get version
+        id: get-version
+        shell: bash
+        run: |
+          VERSION=$(grep -Eo '([0-9]+\.*)+' ${{ vars.VERSION_FILE_PATH }})
+          echo "current-version=$VERSION" >> $GITHUB_ENV
+
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ vars.FRONTEND_PROJECT_BOT_APP_ID }}
+          private_key: ${{ secrets.FRONTEND_PROJECT_BOT_TOKEN }}
+
+      - name: Push tag
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.current-version }}',
+              sha: '${{ github.sha }}'
+            })


### PR DESCRIPTION
Adds a workflow to create a tag with the current version when release PRs are merged.

**NOTE:** this depends requires the creation of an action variable named `VERSION_FILE_PATH` with a value of `Sources/Lytics/Version.swift`