### PR TITLE
Fix Build Error in XCode 15.0 from UIUserInterfaceIdiom.reality

### DIFF
--- a/Sources/Lytics/Extensions/Misc+CustomStringConvertible.swift
+++ b/Sources/Lytics/Extensions/Misc+CustomStringConvertible.swift
@@ -30,7 +30,7 @@ extension UIUserInterfaceIdiom: CustomStringConvertible {
         case .pad: return "pad"
         case .phone: return "phone"
         #if swift(>=5.9)
-        case .reality: return "reality"
+        case .vision: return "vision"
         #endif
         case .tv: return "tv"
         case .unspecified: return "unspecified"


### PR DESCRIPTION
It seems [`UIUserInterfaceIdiom.reality`](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom/reality) is not available outside the visionOS beta, causing a build error with Xcode 15.0. This updates `UIUserInterfaceIdiom.description` to use [`UIUserInterfaceIdiom.vision`](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom/vision?changes=latest_major) instead.