### PR TITLE
Support Automatic Release Notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+changelog:
+  exclude:
+    labels:
+      - chore
+      - ci
+      - ignore-for-release
+    authors:
+      - github-actions
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: New Features 🎉
+      labels:
+        - feature
+    - title: Bug Fixes 🐛
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,7 @@ changelog:
       - ci
       - ignore-for-release
     authors:
+      - frontend-project-bot
       - github-actions
       - octocat
   categories:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,6 +56,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: '${{ env.current-version }}',
+              generate_release_notes: true,
               draft: false,
               prerelease: false
             })

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,5 +46,6 @@ jobs:
           title: '[CI] Bump Version (${{ steps.bump.outputs.version }})'
           body: |
             Update `Version.swift` with bumped version number
+          labels: chore
           draft: false
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Adds a release note configuration file and enables automatic release note generation when creating releases via the `create-release` workflow. The labels in `.github/release.yml` are based on those used by the [conventional-release-labels](https://github.com/bcoe/conventional-release-labels) action.